### PR TITLE
Remove asyncio from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-asyncio
 pytest
 pytest-cov
 pytest-homeassistant-custom-component


### PR DESCRIPTION
## Summary
- remove builtin `asyncio` from requirements

## Testing
- `pytest -q` *(fails: No module named 'syrupy')*
- `pre-commit run --files requirements.txt` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ac8e8d5dc8323b7ca1bc3450f2ce3