### PR TITLE
Add initial test suite

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,45 @@
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.dynamic_energy_calculator.config_flow import (
+    DynamicEnergyCalculatorConfigFlow,
+)
+from custom_components.dynamic_energy_calculator.const import (
+    CONF_CONFIGS,
+    CONF_SOURCE_TYPE,
+    CONF_SOURCES,
+    DOMAIN,
+    SOURCE_TYPE_CONSUMPTION,
+)
+
+
+async def test_flow_no_blocks(hass: HomeAssistant):
+    flow = DynamicEnergyCalculatorConfigFlow()
+    flow.hass = hass
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: "finish"})
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"]["base"] == "no_blocks"
+
+
+async def test_full_flow(hass: HomeAssistant):
+    flow = DynamicEnergyCalculatorConfigFlow()
+    flow.hass = hass
+
+    async def _get_energy():
+        return ["sensor.energy"]
+
+    flow._get_energy_sensors = _get_energy
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION})
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_select_sources({CONF_SOURCES: ["sensor.energy"]})
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: "finish"})
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_CONFIGS] == [
+        {CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION, CONF_SOURCES: ["sensor.energy"]}
+    ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,43 @@
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dynamic_energy_calculator import (
+    async_setup,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.dynamic_energy_calculator.const import DOMAIN, PLATFORMS
+
+
+async def test_async_setup(hass: HomeAssistant):
+    result = await async_setup(hass, {})
+    assert result
+    assert DOMAIN in hass.data
+
+
+async def test_async_setup_and_unload_entry(hass: HomeAssistant):
+    entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="1234")
+    entry.add_to_hass(hass)
+
+    await async_setup(hass, {})
+
+    with pytest.MonkeyPatch.context() as mp:
+        async def forward(entry_to_forward, platforms):
+            assert entry_to_forward is entry
+            assert platforms == PLATFORMS
+        mp.setattr(hass.config_entries, "async_forward_entry_setups", forward)
+        assert await async_setup_entry(hass, entry)
+
+    assert hass.data[DOMAIN][entry.entry_id] == {}
+
+    with pytest.MonkeyPatch.context() as mp:
+        async def unload(entry_to_unload, platforms):
+            assert entry_to_unload is entry
+            assert platforms == PLATFORMS
+            return True
+        mp.setattr(hass.config_entries, "async_unload_platforms", unload)
+        result = await async_unload_entry(hass, entry)
+
+    assert result
+    assert entry.entry_id not in hass.data[DOMAIN]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,84 @@
+import pytest
+from datetime import datetime
+from homeassistant.core import HomeAssistant
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfEnergy
+
+from custom_components.dynamic_energy_calculator.sensor import (
+    BaseUtilitySensor,
+    DynamicEnergySensor,
+    TotalCostSensor,
+    UTILITY_ENTITIES,
+)
+from custom_components.dynamic_energy_calculator.const import (
+    SOURCE_TYPE_CONSUMPTION,
+)
+
+
+async def test_base_sensor_reset_and_set(hass: HomeAssistant):
+    sensor = BaseUtilitySensor(
+        "Test",
+        "uid",
+        UnitOfEnergy.KILO_WATT_HOUR,
+        SensorDeviceClass.ENERGY,
+        "mdi:flash",
+        True,
+    )
+    sensor.hass = hass
+    sensor.async_write_ha_state = lambda *args, **kwargs: None
+    sensor._attr_native_value = 5
+    sensor.reset()
+    assert sensor.native_value == 0
+    sensor.set_value(3.14)
+    assert sensor.native_value == pytest.approx(3.14)
+
+
+async def test_dynamic_energy_sensor_cost(hass: HomeAssistant):
+    price_settings = {
+        "electricity_consumption_markup_per_kwh": 0.0,
+        "electricity_surcharge_per_kwh": 0.0,
+        "vat_percentage": 0.0,
+    }
+    sensor = DynamicEnergySensor(
+        hass,
+        "Test",
+        "uid",
+        "sensor.energy",
+        SOURCE_TYPE_CONSUMPTION,
+        price_settings,
+        price_sensor="sensor.price",
+        mode="cost_total",
+    )
+    sensor._last_energy = 0
+    hass.states.async_set("sensor.energy", 1)
+    hass.states.async_set("sensor.price", 0.5)
+    await sensor.async_update()
+    assert sensor.native_value == pytest.approx(0.5)
+
+
+async def test_total_cost_sensor(hass: HomeAssistant):
+    UTILITY_ENTITIES.clear()
+    cost = DynamicEnergySensor(
+        hass,
+        "Cost",
+        "c1",
+        "sensor.energy",
+        SOURCE_TYPE_CONSUMPTION,
+        {},
+        mode="cost_total",
+    )
+    profit = DynamicEnergySensor(
+        hass,
+        "Profit",
+        "p1",
+        "sensor.energy",
+        SOURCE_TYPE_CONSUMPTION,
+        {},
+        mode="profit_total",
+    )
+    UTILITY_ENTITIES.extend([cost, profit])
+    cost._attr_native_value = 5
+    profit._attr_native_value = 2
+    total = TotalCostSensor(hass, "Total", "t1", None)
+    await total.async_update()
+    assert total.native_value == pytest.approx(3)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,56 @@
+import pytest
+from homeassistant.core import HomeAssistant, ServiceCall
+
+from custom_components.dynamic_energy_calculator.services import (
+    async_register_services,
+    _handle_reset_all,
+    _handle_reset_sensors,
+    _handle_set_value,
+)
+from custom_components.dynamic_energy_calculator.const import DOMAIN
+
+
+async def test_service_registration(hass: HomeAssistant):
+    await async_register_services(hass)
+    assert hass.services.has_service(DOMAIN, "reset_all_meters")
+    assert hass.services.has_service(DOMAIN, "reset_selected_meters")
+    assert hass.services.has_service(DOMAIN, "set_meter_value")
+
+
+async def test_service_handlers(hass: HomeAssistant):
+    called = {
+        "reset": False,
+        "set": False,
+    }
+
+    class Dummy:
+        async def async_reset(self):
+            called["reset"] = True
+
+        async def async_set_value(self, value):
+            called["set"] = value
+
+    hass.data[DOMAIN] = {"entities": {"dynamic_energy_calculator.test": Dummy()}}
+    hass.states.async_set("dynamic_energy_calculator.test", 1)
+
+    def ids(prefix=None):
+        if prefix == f"{DOMAIN}.":
+            return ["dynamic_energy_calculator.test"]
+        return []
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(hass.states.__class__, "async_entity_ids", lambda self, prefix=None: ids(prefix))
+
+    await _handle_reset_all(ServiceCall(hass, DOMAIN, "reset_all_meters", {}))
+    assert called["reset"]
+
+    called["reset"] = False
+    await _handle_reset_sensors(
+        ServiceCall(hass, DOMAIN, "reset_selected_meters", {"entity_ids": ["dynamic_energy_calculator.test"]})
+    )
+    assert called["reset"]
+
+    await _handle_set_value(
+        ServiceCall(hass, DOMAIN, "set_meter_value", {"entity_id": "dynamic_energy_calculator.test", "value": 5})
+    )
+    assert called["set"] == 5


### PR DESCRIPTION
## Summary
- implement tests for initialization
- add config flow tests
- cover main sensor logic
- validate service handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad1fb7a208323abe0f1498b2ee7f4