### PR TITLE
Add tests

### DIFF
--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,42 @@
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dynamic_energy_calculator.config_flow import (
+    DynamicEnergyCalculatorOptionsFlowHandler,
+)
+from custom_components.dynamic_energy_calculator.const import (
+    CONF_CONFIGS,
+    CONF_SOURCE_TYPE,
+    CONF_SOURCES,
+    SOURCE_TYPE_CONSUMPTION,
+)
+
+
+async def test_options_flow_no_blocks(hass: HomeAssistant):
+    entry = MockConfigEntry(domain="dynamic_energy_calculator", data={}, entry_id="1")
+    flow = DynamicEnergyCalculatorOptionsFlowHandler(entry)
+    flow.hass = hass
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: "finish"})
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"]["base"] == "no_blocks"
+
+
+async def test_options_flow_full_flow(hass: HomeAssistant):
+    entry = MockConfigEntry(domain="dynamic_energy_calculator", data={}, entry_id="1")
+    flow = DynamicEnergyCalculatorOptionsFlowHandler(entry)
+    flow.hass = hass
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION})
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_select_sources({CONF_SOURCES: ["sensor.energy"]})
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: "finish"})
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_CONFIGS] == [
+        {CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION, CONF_SOURCES: ["sensor.energy"]}
+    ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -10,6 +10,7 @@ from custom_components.dynamic_energy_calculator.sensor import (
     TotalCostSensor,
     TotalEnergyCostSensor,
     DailyGasCostSensor,
+    DailyElectricityCostSensor,
     CurrentElectricityPriceSensor,
     UTILITY_ENTITIES,
 )
@@ -124,6 +125,22 @@ async def test_daily_gas_cost_sensor(hass: HomeAssistant):
     assert sensor._calculate_daily_cost() == pytest.approx(0.5)
 
 
+async def test_daily_electricity_cost_sensor(hass: HomeAssistant):
+    sensor = DailyElectricityCostSensor(
+        hass,
+        "Electric Fixed",
+        "eid",
+        {
+            "electricity_surcharge_per_day": 0.5,
+            "electricity_standing_charge_per_day": 0.2,
+            "electricity_tax_rebate_per_day": 0.1,
+            "vat_percentage": 0.0,
+        },
+        DeviceInfo(identifiers={("dec", "test")}),
+    )
+    assert sensor._calculate_daily_cost() == pytest.approx(0.6)
+
+
 async def test_current_gas_consumption_price(hass: HomeAssistant):
     price_settings = {
         "gas_markup_per_m3": 0.0,
@@ -141,6 +158,20 @@ async def test_current_gas_consumption_price(hass: HomeAssistant):
         device=DeviceInfo(identifiers={("dec", "test")}),
     )
     assert sensor.native_unit_of_measurement == "€/m³"
+
+
+async def test_current_electricity_price(hass: HomeAssistant):
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Elec Price",
+        "eid",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_CONSUMPTION,
+        price_settings={"vat_percentage": 0.0},
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("dec", "test")}),
+    )
+    assert sensor.native_unit_of_measurement == "€/kWh"
 
 
 async def test_total_energy_cost_multiple(hass: HomeAssistant):

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -1,0 +1,41 @@
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from custom_components.dynamic_energy_calculator.sensor import async_setup_entry
+from custom_components.dynamic_energy_calculator.const import (
+    DOMAIN,
+    CONF_CONFIGS,
+    CONF_SOURCE_TYPE,
+    CONF_SOURCES,
+    CONF_PRICE_SENSOR,
+    CONF_PRICE_SETTINGS,
+    SOURCE_TYPE_CONSUMPTION,
+)
+
+
+async def test_async_setup_entry(hass: HomeAssistant):
+    from custom_components.dynamic_energy_calculator import async_setup
+
+    await async_setup(hass, {})
+    hass.states.async_set("sensor.energy", 0)
+    hass.states.async_set("sensor.price", 0)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_CONFIGS: [
+                {CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION, CONF_SOURCES: ["sensor.energy"]}
+            ],
+            CONF_PRICE_SENSOR: "sensor.price",
+        },
+        options={CONF_PRICE_SETTINGS: {}},
+    )
+    entry.add_to_hass(hass)
+    added = []
+
+    async def add_entities(entities, update=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, add_entities)
+    await hass.async_block_till_done()
+    assert isinstance(added, list)
+    assert hass.services.has_service(DOMAIN, "reset_all_meters")


### PR DESCRIPTION
## Summary
- add options flow tests
- test daily electricity cost
- test electricity price unit
- set up sensors in integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ca4e1e0cc8323b20a4d242bc6c27e