### PR TITLE
Fix missing syrupy plugin for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pytest-homeassistant-custom-component
+syrupy


### PR DESCRIPTION
## Summary
- include `syrupy` snapshot plugin in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cabdad9248323979f2c892e6ffd43