### PR TITLE
Add async sensor methods

### DIFF
--- a/custom_components/dynamic_energy_calculator/sensor.py
+++ b/custom_components/dynamic_energy_calculator/sensor.py
@@ -140,6 +140,14 @@ class BaseUtilitySensor(SensorEntity, RestoreEntity):
         self._attr_native_value = round(value, 8)
         self.async_write_ha_state()
 
+    async def async_reset(self) -> None:
+        """Async wrapper for reset."""
+        self.reset()
+
+    async def async_set_value(self, value: float) -> None:
+        """Async wrapper for set_value."""
+        self.set_value(value)
+
 
 class TotalCostSensor(BaseUtilitySensor):
     def __init__(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,6 +8,7 @@ from custom_components.dynamic_energy_calculator.services import (
     _handle_set_value,
 )
 from custom_components.dynamic_energy_calculator.const import DOMAIN
+from custom_components.dynamic_energy_calculator.sensor import BaseUtilitySensor
 
 
 async def test_service_registration(hass: HomeAssistant):
@@ -23,11 +24,16 @@ async def test_service_handlers(hass: HomeAssistant):
         "set": False,
     }
 
-    class Dummy:
-        async def async_reset(self):
+    class Dummy(BaseUtilitySensor):
+        def __init__(self):
+            super().__init__("Test", "uid", "€", None, "mdi:flash", True)
+            self.hass = hass
+            self.async_write_ha_state = lambda *a, **k: None
+
+        def reset(self):
             called["reset"] = True
 
-        async def async_set_value(self, value):
+        def set_value(self, value):
             called["set"] = value
 
     hass.data[DOMAIN] = {"entities": {"dynamic_energy_calculator.test": Dummy()}}


### PR DESCRIPTION
## Summary
- implement `async_reset` and `async_set_value` wrappers in BaseUtilitySensor
- adjust service handler tests to use new async wrappers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cabd8def88323a978e71f1da00f29