### PR TITLE
Add diagnostics module

### DIFF
--- a/custom_components/dynamic_energy_calculator/diagnostics.py
+++ b/custom_components/dynamic_energy_calculator/diagnostics.py
@@ -1,0 +1,41 @@
+"""Diagnostics support for Dynamic Energy Contract Calculator."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_CONFIGS, CONF_SOURCES
+
+
+REDACT_CONFIG = set()
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+
+    data = {
+        "entry": {
+            "data": async_redact_data(dict(entry.data), REDACT_CONFIG),
+            "options": async_redact_data(dict(entry.options), REDACT_CONFIG),
+        },
+        "sources": [],
+    }
+
+    for block in entry.data.get(CONF_CONFIGS, []):
+        for source in block.get(CONF_SOURCES, []):
+            state = hass.states.get(source)
+            data["sources"].append(
+                {
+                    "entity_id": source,
+                    "state": state.state if state else None,
+                    "attributes": dict(state.attributes) if state else {},
+                }
+            )
+
+    return data


### PR DESCRIPTION
## Summary
- add diagnostics module for returning sanitized sensor diagnostics

## Testing
- `pre-commit run --files custom_components/dynamic_energy_calculator/diagnostics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc5582f788323a606a4576daeb86d