### PR TITLE
Set diagnostic entity category for fixed cost sensors

### DIFF
--- a/custom_components/dynamic_energy_calculator/quality_scale.yaml
+++ b/custom_components/dynamic_energy_calculator/quality_scale.yaml
@@ -72,7 +72,7 @@ rules:
     status: exempt
     comment: |
       Static set of devices.
-  entity-category: todo
+  entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: todo

--- a/custom_components/dynamic_energy_calculator/sensor.py
+++ b/custom_components/dynamic_energy_calculator/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.event import (
     async_track_time_change,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from .const import (
     DOMAIN,
@@ -165,6 +165,7 @@ class TotalCostSensor(BaseUtilitySensor):
             visible=True,
             device=device,
         )
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
 
     async def async_update(self):
@@ -407,6 +408,7 @@ class DailyElectricityCostSensor(BaseUtilitySensor):
             visible=True,
             device=device,
         )
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.price_settings = price_settings
 
@@ -473,6 +475,7 @@ class DailyGasCostSensor(BaseUtilitySensor):
             visible=True,
             device=device,
         )
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.price_settings = price_settings
 
@@ -534,6 +537,7 @@ class TotalEnergyCostSensor(BaseUtilitySensor):
             visible=True,
             device=device,
         )
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.net_cost_entity_id = net_cost_entity_id
         self.fixed_cost_entity_ids = fixed_cost_entity_ids
@@ -606,6 +610,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             visible=True,
             device=device,
         )
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.price_sensor = price_sensor
         self.source_type = source_type

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,7 +2,7 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import UnitOfEnergy, UnitOfVolume
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from custom_components.dynamic_energy_calculator.sensor import (
     BaseUtilitySensor,
@@ -122,6 +122,7 @@ async def test_daily_gas_cost_sensor(hass: HomeAssistant):
         {"gas_standing_charge_per_day": 0.5, "vat_percentage": 0.0},
         DeviceInfo(identifiers={("dec", "test")}),
     )
+    assert sensor.entity_category is EntityCategory.DIAGNOSTIC
     assert sensor._calculate_daily_cost() == pytest.approx(0.5)
 
 
@@ -138,6 +139,7 @@ async def test_daily_electricity_cost_sensor(hass: HomeAssistant):
         },
         DeviceInfo(identifiers={("dec", "test")}),
     )
+    assert sensor.entity_category is EntityCategory.DIAGNOSTIC
     assert sensor._calculate_daily_cost() == pytest.approx(0.6)
 
 


### PR DESCRIPTION
## Summary
- mark fixed cost sensors as diagnostic with `EntityCategory.DIAGNOSTIC`
- update tests for the new entity category
- note completion of `entity-category` rule in quality scale

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc8963c20832382e8eca6e079f7e3