### PR TITLE
Fix timezone for Home Assistant tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,14 @@
+import os
+import time
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
 async def set_time_zone(hass):
     """Set a valid IANA time zone for Home Assistant tests."""
+    os.environ["TZ"] = "America/Los_Angeles"
+    if hasattr(time, "tzset"):
+        time.tzset()
     await hass.config.async_set_time_zone("America/Los_Angeles")
     yield


### PR DESCRIPTION
## Summary
- ensure TZ environment variable is valid for Home Assistant tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d266302448323aa324b180fe3da4a