### PR TITLE
Fix release workflow indentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
 
       - name: Patch manifest and zip
         run: |
-            sed -i 's/v0.0.0/${{ steps.version.outputs.version }}/' custom_components/dynamic_energy_calculator/manifest.json
-            cd custom_components/dynamic_energy_calculator/
-            zip ../../dynamic_energy_calculator.zip -r ./
+          sed -i 's/v0.0.0/${{ steps.version.outputs.version }}/' custom_components/dynamic_energy_calculator/manifest.json
+          cd custom_components/dynamic_energy_calculator/
+          zip ../../dynamic_energy_calculator.zip -r ./
       - uses: svenstaro/upload-release-action@master
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-            file: ./dynamic_energy_calculator.zip
-            asset_name: dynamic_energy_calculator.zip
+          file: ./dynamic_energy_calculator.zip
+          asset_name: dynamic_energy_calculator.zip
           tag: ${{ github.ref }}
           overwrite: true


### PR DESCRIPTION
## Summary
- tidy indentation of `release.yml` for GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d291e99ac8323bfed8153063aff99