### PR TITLE
Clarify price calculations

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -256,11 +256,16 @@ class DailyGasCostSensor(BaseUtilitySensor):
     def _calculate_daily_cost(self) -> float:
         vat = self.price_settings.get("vat_percentage", 21.0)
         standing = self.price_settings.get("per_day_supplier_gas_standing_charge", 0.0)
+        surcharge = self.price_settings.get(
+            "per_day_grid_operator_gas_connection_fee", 0.0
+        )
 
-        total = standing * (1 + vat / 100)
+        subtotal = standing + surcharge
+        total = subtotal * (1 + vat / 100)
         _LOGGER.debug(
-            "Daily gas cost calc: standing=%s vat=%s -> %s",
+            "Daily gas cost calc: standing=%s surcharge=%s vat=%s -> %s",
             standing,
+            surcharge,
             vat,
             total,
         )


### PR DESCRIPTION
## Summary
- detail how all price settings are applied
- use `per_day_grid_operator_gas_connection_fee` when calculating daily gas costs

## Testing
- `pre-commit run --files README.md custom_components/dynamic_energy_contract_calculator/sensor.py tests/test_sensor.py tests/test_sensor_additional.py` *(fails: mypy errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dfc99b7c083238430af890cf81d19