### PR TITLE
Allow integer inputs in configuration

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_contract_calculator/config_flow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import voluptuous as vol
+
+NUMBER = vol.Any(vol.Coerce(int), vol.Coerce(float))
 import copy
 
 from typing import Any
@@ -188,7 +190,7 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
             if isinstance(default, bool):
                 schema_fields[vol.Required(key, default=current)] = bool
             else:
-                schema_fields[vol.Required(key, default=current)] = vol.Coerce(float)
+                schema_fields[vol.Required(key, default=current)] = NUMBER
 
         return self.async_show_form(
             step_id=STEP_PRICE_SETTINGS,
@@ -360,7 +362,7 @@ class DynamicEnergyCalculatorOptionsFlowHandler(config_entries.OptionsFlow):
             if isinstance(default, bool):
                 schema_fields[vol.Required(key, default=current)] = bool
             else:
-                schema_fields[vol.Required(key, default=current)] = vol.Coerce(float)
+                schema_fields[vol.Required(key, default=current)] = NUMBER
 
         return self.async_show_form(
             step_id=STEP_PRICE_SETTINGS,

--- a/custom_components/dynamic_energy_contract_calculator/services.py
+++ b/custom_components/dynamic_energy_contract_calculator/services.py
@@ -3,6 +3,8 @@
 import logging
 import voluptuous as vol
 
+NUMBER = vol.Any(vol.Coerce(int), vol.Coerce(float))
+
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 
@@ -21,7 +23,7 @@ RESET_SENSORS_SCHEMA = vol.Schema(
 SET_VALUE_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_id,
-        vol.Required("value"): vol.Coerce(float),
+        vol.Required("value"): NUMBER,
     }
 )
 

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -55,8 +55,8 @@ async def test_options_flow_price_settings(hass: HomeAssistant):
     result = await flow.async_step_user({CONF_SOURCE_TYPE: "price_settings"})
     assert result["type"] == FlowResultType.FORM
 
-    result = await flow.async_step_price_settings({"vat_percentage": 10.0})
-    assert flow.price_settings["vat_percentage"] == 10.0
+    result = await flow.async_step_price_settings({"vat_percentage": 10})
+    assert flow.price_settings["vat_percentage"] == 10
     assert result["type"] == FlowResultType.FORM
 
 


### PR DESCRIPTION
## Summary
- accept integers or floats for price setting inputs
- accept integers for value in services
- test integer input in options flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688351f8be4c8323b9c0b7635ce96078