### PR TITLE
Allow selecting multiple cost sensors

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_contract_calculator/config_flow.py
@@ -156,15 +156,19 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
             or state.attributes.get("unit_of_measurement") == "€/m³"
             or state.attributes.get("unit_of_measurement") == "€/kWh"
         ]
-        current_price_sensor = self.price_settings.get(CONF_PRICE_SENSOR, "")
-        current_price_sensor_gas = self.price_settings.get(CONF_PRICE_SENSOR_GAS, "")
+        current_price_sensor = self.price_settings.get(CONF_PRICE_SENSOR, [])
+        if isinstance(current_price_sensor, str):
+            current_price_sensor = [current_price_sensor]
+        current_price_sensor_gas = self.price_settings.get(CONF_PRICE_SENSOR_GAS, [])
+        if isinstance(current_price_sensor_gas, str):
+            current_price_sensor_gas = [current_price_sensor_gas]
 
         schema_fields: dict[Any, Any] = {
             vol.Required(CONF_PRICE_SENSOR, default=current_price_sensor): selector(
                 {
                     "select": {
                         "options": all_prices,
-                        "multiple": False,
+                        "multiple": True,
                         "mode": "dropdown",
                     }
                 }
@@ -175,7 +179,7 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
                 {
                     "select": {
                         "options": all_prices,
-                        "multiple": False,
+                        "multiple": True,
                         "mode": "dropdown",
                     }
                 }
@@ -328,15 +332,19 @@ class DynamicEnergyCalculatorOptionsFlowHandler(config_entries.OptionsFlow):
             or state.attributes.get("unit_of_measurement") == "€/m³"
             or state.attributes.get("unit_of_measurement") == "€/kWh"
         ]
-        current_price_sensor = self.price_settings.get(CONF_PRICE_SENSOR, "")
-        current_price_sensor_gas = self.price_settings.get(CONF_PRICE_SENSOR_GAS, "")
+        current_price_sensor = self.price_settings.get(CONF_PRICE_SENSOR, [])
+        if isinstance(current_price_sensor, str):
+            current_price_sensor = [current_price_sensor]
+        current_price_sensor_gas = self.price_settings.get(CONF_PRICE_SENSOR_GAS, [])
+        if isinstance(current_price_sensor_gas, str):
+            current_price_sensor_gas = [current_price_sensor_gas]
 
         schema_fields = {
             vol.Required(CONF_PRICE_SENSOR, default=current_price_sensor): selector(
                 {
                     "select": {
                         "options": all_prices,
-                        "multiple": False,
+                        "multiple": True,
                         "mode": "dropdown",
                     }
                 }
@@ -347,7 +355,7 @@ class DynamicEnergyCalculatorOptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     "select": {
                         "options": all_prices,
-                        "multiple": False,
+                        "multiple": True,
                         "mode": "dropdown",
                     }
                 }

--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -234,24 +234,27 @@ class DynamicEnergySensor(BaseUtilitySensor):
             valid = False
             for sensor_id in self.price_sensors:
                 price_state = self.hass.states.get(sensor_id)
-                if price_state is None or price_state.state in ("unknown", "unavailable"):
+                if price_state is None or price_state.state in (
+                    "unknown",
+                    "unavailable",
+                ):
                     _LOGGER.warning("Price sensor %s is unavailable", sensor_id)
                     continue
                 try:
                     total_price += float(price_state.state)
                     valid = True
                 except ValueError:
-                    _LOGGER.warning(
-                        "Price sensor %s has invalid state", sensor_id
-                    )
+                    _LOGGER.warning("Price sensor %s has invalid state", sensor_id)
                     continue
             if not valid:
                 self._attr_available = False
                 if self._price_unavailable_since is None:
                     self._price_unavailable_since = datetime.now()
-                if datetime.now() - self._price_unavailable_since >= timedelta(
-                    seconds=UNAVAILABLE_GRACE_SECONDS
-                ) and self.price_sensor:
+                if (
+                    datetime.now() - self._price_unavailable_since
+                    >= timedelta(seconds=UNAVAILABLE_GRACE_SECONDS)
+                    and self.price_sensor
+                ):
                     async_report_issue(
                         self.hass,
                         f"price_unavailable_{self.price_sensor}",

--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -99,7 +99,7 @@ class DynamicEnergySensor(BaseUtilitySensor):
         energy_sensor: str,
         source_type: str,
         price_settings: dict[str, float],
-        price_sensor: str | None = None,
+        price_sensor: str | list[str] | None = None,
         mode: str = "kwh_total",
         unit: str = UnitOfEnergy.KILO_WATT_HOUR,
         device_class: SensorDeviceClass | str | None = None,
@@ -121,8 +121,14 @@ class DynamicEnergySensor(BaseUtilitySensor):
             self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self.hass = hass
         self.energy_sensor = energy_sensor
-        self.input_sensors = [energy_sensor]
-        self.price_sensor = price_sensor
+        if isinstance(price_sensor, list):
+            self.price_sensors = price_sensor
+        elif price_sensor is None:
+            self.price_sensors = []
+        else:
+            self.price_sensors = [price_sensor]
+        self.price_sensor = self.price_sensors[0] if self.price_sensors else None
+        self.input_sensors = [energy_sensor] + self.price_sensors
         self.mode = mode
         self.source_type = source_type
         self.price_settings = price_settings
@@ -212,7 +218,7 @@ class DynamicEnergySensor(BaseUtilitySensor):
 
         self._last_energy = current_energy
 
-        if self.mode not in ("kwh_total", "m3_total") and not self.price_sensor:
+        if self.mode not in ("kwh_total", "m3_total") and not self.price_sensors:
             async_report_issue(
                 self.hass,
                 f"missing_price_sensor_{self.entity_id}",
@@ -223,16 +229,29 @@ class DynamicEnergySensor(BaseUtilitySensor):
 
         if self.mode in ("kwh_total", "m3_total"):
             self._attr_native_value += delta
-        elif self.price_sensor:
-            price_state = self.hass.states.get(self.price_sensor)
-            if price_state is None or price_state.state in ("unknown", "unavailable"):
+        elif self.price_sensors:
+            total_price = 0.0
+            valid = False
+            for sensor_id in self.price_sensors:
+                price_state = self.hass.states.get(sensor_id)
+                if price_state is None or price_state.state in ("unknown", "unavailable"):
+                    _LOGGER.warning("Price sensor %s is unavailable", sensor_id)
+                    continue
+                try:
+                    total_price += float(price_state.state)
+                    valid = True
+                except ValueError:
+                    _LOGGER.warning(
+                        "Price sensor %s has invalid state", sensor_id
+                    )
+                    continue
+            if not valid:
                 self._attr_available = False
                 if self._price_unavailable_since is None:
                     self._price_unavailable_since = datetime.now()
                 if datetime.now() - self._price_unavailable_since >= timedelta(
                     seconds=UNAVAILABLE_GRACE_SECONDS
-                ):
-                    _LOGGER.warning("Price sensor %s is unavailable", self.price_sensor)
+                ) and self.price_sensor:
                     async_report_issue(
                         self.hass,
                         f"price_unavailable_{self.price_sensor}",
@@ -240,31 +259,13 @@ class DynamicEnergySensor(BaseUtilitySensor):
                         {"sensor": self.price_sensor},
                     )
                 return
-            try:
-                price = float(price_state.state)
-            except ValueError:
-                self._attr_available = False
-                if self._price_unavailable_since is None:
-                    self._price_unavailable_since = datetime.now()
-                if datetime.now() - self._price_unavailable_since >= timedelta(
-                    seconds=UNAVAILABLE_GRACE_SECONDS
-                ):
-                    _LOGGER.warning(
-                        "Price sensor %s has invalid state", self.price_sensor
-                    )
-                    async_report_issue(
-                        self.hass,
-                        f"price_invalid_{self.price_sensor}",
-                        "price_sensor_unavailable",
-                        {"sensor": self.price_sensor},
-                    )
-                return
             self._attr_available = True
-            if self._price_unavailable_since is not None:
+            if self._price_unavailable_since is not None and self.price_sensor:
                 async_clear_issue(self.hass, f"price_unavailable_{self.price_sensor}")
                 async_clear_issue(self.hass, f"price_invalid_{self.price_sensor}")
                 self._price_unavailable_since = None
 
+            price = total_price
             if (
                 self.source_type == SOURCE_TYPE_CONSUMPTION
                 or self.source_type == SOURCE_TYPE_GAS
@@ -283,7 +284,7 @@ class DynamicEnergySensor(BaseUtilitySensor):
             _LOGGER.debug(
                 "Calculated price for %s: base=%s markup_c=%s markup_p=%s tax=%s vat=%s -> %s",
                 self.entity_id,
-                price_state.state,
+                total_price,
                 markup_consumption,
                 markup_production,
                 tax,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -67,6 +67,30 @@ async def test_dynamic_energy_sensor_cost(hass: HomeAssistant):
     assert sensor.native_value == pytest.approx(0.5)
 
 
+async def test_dynamic_energy_sensor_multiple_prices(hass: HomeAssistant):
+    price_settings = {
+        "per_unit_supplier_electricity_markup": 0.0,
+        "per_unit_government_electricity_tax": 0.0,
+        "vat_percentage": 0.0,
+    }
+    sensor = DynamicEnergySensor(
+        hass,
+        "TestMulti",
+        "uidmulti",
+        "sensor.energy",
+        SOURCE_TYPE_CONSUMPTION,
+        price_settings,
+        price_sensor=["sensor.price1", "sensor.price2"],
+        mode="cost_total",
+    )
+    sensor._last_energy = 0
+    hass.states.async_set("sensor.energy", 1)
+    hass.states.async_set("sensor.price1", 0.3)
+    hass.states.async_set("sensor.price2", 0.2)
+    await sensor.async_update()
+    assert sensor.native_value == pytest.approx(0.5)
+
+
 async def test_dynamic_gas_sensor_cost(hass: HomeAssistant):
     price_settings = {
         "per_unit_supplier_gas_markup": 0.0,

--- a/tests/test_sensor_additional.py
+++ b/tests/test_sensor_additional.py
@@ -110,7 +110,7 @@ async def test_dynamic_sensor_added_to_hass(hass: HomeAssistant):
         )
         await sensor.async_added_to_hass()
 
-    assert called == ["sensor.energy", "unsub"]
+    assert called == ["sensor.energy", "unsub", "sensor.price", "unsub"]
 
 
 async def test_total_cost_sensor_added(hass: HomeAssistant):
@@ -305,7 +305,7 @@ async def test_async_setup_entry_gas(hass: HomeAssistant):
             CONF_CONFIGS: [
                 {CONF_SOURCE_TYPE: SOURCE_TYPE_GAS, CONF_SOURCES: ["sensor.gas"]}
             ],
-            CONF_PRICE_SENSOR_GAS: "sensor.gprice",
+            CONF_PRICE_SENSOR_GAS: ["sensor.gprice"],
         },
         options={CONF_PRICE_SETTINGS: {}},
     )

--- a/tests/test_sensor_platform_setup.py
+++ b/tests/test_sensor_platform_setup.py
@@ -30,7 +30,7 @@ async def test_async_setup_entry(hass: HomeAssistant):
                     CONF_SOURCES: ["sensor.energy"],
                 }
             ],
-            CONF_PRICE_SENSOR: "sensor.price",
+            CONF_PRICE_SENSOR: ["sensor.price"],
         },
         options={CONF_PRICE_SETTINGS: {}},
     )


### PR DESCRIPTION
## Summary
- allow choosing multiple cost sensors in config and options flows
- sum values from multiple price sensors in calculations and current price sensors
- test multi-sensor price calculation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689478b1264083238a06a12c33575dea