### PR TITLE
Skip cost sensors without price

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -219,12 +219,10 @@ class DynamicEnergySensor(BaseUtilitySensor):
         self._last_energy = current_energy
 
         if self.mode not in ("kwh_total", "m3_total") and not self.price_sensors:
-            async_report_issue(
-                self.hass,
-                f"missing_price_sensor_{self.entity_id}",
-                "missing_price_sensor",
-                {"sensor": self.entity_id},
+            _LOGGER.debug(
+                "Skipping update for %s due to missing price sensor", self.entity_id
             )
+            self._attr_available = False
             return
 
         if self.mode in ("kwh_total", "m3_total"):

--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -575,6 +575,8 @@ async def async_setup_entry(
 
             for mode_def in mode_defs:
                 mode = mode_def["key"]
+                if not selected_price_sensor and mode not in ("kwh_total", "m3_total"):
+                    continue
                 uid = f"{DOMAIN}_{base_id}_{mode}"
                 entities.append(
                     DynamicEnergySensor(

--- a/custom_components/dynamic_energy_contract_calculator/translations/en.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/en.json
@@ -123,10 +123,6 @@
     }
     },
     "issues": {
-    "missing_price_sensor": {
-      "title": "Missing price sensor",
-      "description": "A price sensor is required for calculating energy costs."
-    },
     "energy_source_unavailable": {
       "title": "Energy source unavailable",
       "description": "Energy sensor {sensor} is unavailable or has invalid data."

--- a/custom_components/dynamic_energy_contract_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/nl.json
@@ -149,10 +149,6 @@
     }
   },
   "issues": {
-    "missing_price_sensor": {
-      "title": "Ontbrekende prijssensor",
-      "description": "Er is een prijssensor nodig om kosten te berekenen."
-    },
     "energy_source_unavailable": {
       "title": "Energiebron niet beschikbaar",
       "description": "Energiebron {sensor} is niet beschikbaar of ongeldig."

--- a/tests/test_entity_edge_cases.py
+++ b/tests/test_entity_edge_cases.py
@@ -71,7 +71,7 @@ async def test_delta_negative(hass: HomeAssistant):
     assert sensor.native_value == 0
 
 
-async def test_missing_price_sensor(hass: HomeAssistant):
+async def test_missing_price_sensor_no_issue(hass: HomeAssistant):
     sensor = await _make_sensor(hass, price_sensor=None)
     sensor._last_energy = 0
     hass.states.async_set("sensor.energy", 1)
@@ -82,7 +82,7 @@ async def test_missing_price_sensor(hass: HomeAssistant):
             lambda *a, **k: called.update(missing=True),
         )
         await sensor.async_update()
-    assert called.get("missing")
+    assert not called
 
 
 async def test_price_unavailable(hass: HomeAssistant):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -350,7 +350,7 @@ async def test_production_price_no_vat(hass: HomeAssistant):
     assert sensor.native_value == pytest.approx(1.0)
 
 
-async def test_missing_price_sensor_issue_called(hass: HomeAssistant):
+async def test_missing_price_sensor_no_issue(hass: HomeAssistant):
     price_settings = {}
     sensor = DynamicEnergySensor(
         hass,
@@ -376,7 +376,7 @@ async def test_missing_price_sensor_issue_called(hass: HomeAssistant):
             fake_issue,
         )
         await sensor.async_update()
-    assert called.get("key") == "missing_price_sensor"
+    assert not called
 
 
 async def test_base_sensor_restore_state(hass: HomeAssistant):

--- a/tests/test_sensor_platform_setup.py
+++ b/tests/test_sensor_platform_setup.py
@@ -44,3 +44,38 @@ async def test_async_setup_entry(hass: HomeAssistant):
     await hass.async_block_till_done()
     assert isinstance(added, list)
     assert hass.services.has_service(DOMAIN, "reset_all_meters")
+
+
+async def test_setup_entry_without_price_sensor(hass: HomeAssistant):
+    from custom_components.dynamic_energy_contract_calculator import async_setup
+
+    await async_setup(hass, {})
+    hass.states.async_set("sensor.energy", 0)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_CONFIGS: [
+                {
+                    CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION,
+                    CONF_SOURCES: ["sensor.energy"],
+                }
+            ],
+        },
+        options={CONF_PRICE_SETTINGS: {}},
+    )
+    entry.add_to_hass(hass)
+
+    added: list[str] = []
+
+    async def add_entities(entities, update=False):
+        added.extend([e.unique_id for e in entities])
+
+    await async_setup_entry(hass, entry, add_entities)
+    await hass.async_block_till_done()
+
+    energy_ids = {uid for uid in added if uid.startswith(f"{DOMAIN}_sensor_energy_")}
+    assert f"{DOMAIN}_sensor_energy_cost_total" not in energy_ids
+    assert f"{DOMAIN}_sensor_energy_profit_total" not in energy_ids
+    assert f"{DOMAIN}_sensor_energy_kwh_during_cost_total" not in energy_ids
+    assert f"{DOMAIN}_sensor_energy_kwh_during_profit_total" not in energy_ids


### PR DESCRIPTION
## Summary
- Avoid creating cost and profit sensors when no price sensor is configured
- Stop reporting missing_price_sensor issues and mark sensors unavailable instead
- Add tests covering sensor creation without price sensor and absence of repair issues

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959a64bef483238219595dd2e1c435