### PR TITLE
Aggregate raw price lists from multiple sensors

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -513,7 +513,9 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                             continue
                         if idx < len(raw_today):
                             try:
-                                raw_today[idx]["value"] = float(raw_today[idx]["value"]) + add_val
+                                raw_today[idx]["value"] = (
+                                    float(raw_today[idx]["value"]) + add_val
+                                )
                             except (ValueError, TypeError, KeyError):
                                 raw_today[idx]["value"] = add_val
                         else:
@@ -524,7 +526,9 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             st_raw_tomorrow = state.attributes.get("raw_tomorrow")
             if isinstance(st_raw_tomorrow, list):
                 if raw_tomorrow is None:
-                    raw_tomorrow = [e.copy() for e in st_raw_tomorrow if isinstance(e, dict)]
+                    raw_tomorrow = [
+                        e.copy() for e in st_raw_tomorrow if isinstance(e, dict)
+                    ]
                 else:
                     for idx, entry in enumerate(st_raw_tomorrow):
                         if not isinstance(entry, dict) or "value" not in entry:
@@ -535,7 +539,9 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                             continue
                         if idx < len(raw_tomorrow):
                             try:
-                                raw_tomorrow[idx]["value"] = float(raw_tomorrow[idx]["value"]) + add_val
+                                raw_tomorrow[idx]["value"] = (
+                                    float(raw_tomorrow[idx]["value"]) + add_val
+                                )
                             except (ValueError, TypeError, KeyError):
                                 raw_tomorrow[idx]["value"] = add_val
                         else:

--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -456,8 +456,16 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
         return round(price, 8)
 
     def _convert_raw_prices(self, raw_prices):
+        """Convert raw price entries by applying price settings.
+
+        The input may be a list accumulated from multiple price sensors.
+        Each entry is copied before modification to avoid mutating the
+        original structure.
+        """
+
         if not isinstance(raw_prices, list):
             return None
+
         converted = []
         for entry in raw_prices:
             if not isinstance(entry, dict) or "value" not in entry:
@@ -466,9 +474,11 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                 base = float(entry["value"])
             except (ValueError, TypeError):
                 continue
+
             entry_conv = entry.copy()
             entry_conv["value"] = self._calculate_price(base)
             converted.append(entry_conv)
+
         return converted
 
     async def async_update(self):
@@ -476,6 +486,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
         raw_today = None
         raw_tomorrow = None
         valid = False
+
         for sensor in self.price_sensors:
             state = self.hass.states.get(sensor)
             if state is None or state.state in ("unknown", "unavailable"):
@@ -487,9 +498,50 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             except ValueError:
                 _LOGGER.warning("Price sensor %s has invalid state", sensor)
                 continue
-            if raw_today is None:
-                raw_today = state.attributes.get("raw_today")
-                raw_tomorrow = state.attributes.get("raw_tomorrow")
+
+            st_raw_today = state.attributes.get("raw_today")
+            if isinstance(st_raw_today, list):
+                if raw_today is None:
+                    raw_today = [e.copy() for e in st_raw_today if isinstance(e, dict)]
+                else:
+                    for idx, entry in enumerate(st_raw_today):
+                        if not isinstance(entry, dict) or "value" not in entry:
+                            continue
+                        try:
+                            add_val = float(entry["value"])
+                        except (ValueError, TypeError):
+                            continue
+                        if idx < len(raw_today):
+                            try:
+                                raw_today[idx]["value"] = float(raw_today[idx]["value"]) + add_val
+                            except (ValueError, TypeError, KeyError):
+                                raw_today[idx]["value"] = add_val
+                        else:
+                            new_entry = entry.copy()
+                            new_entry["value"] = add_val
+                            raw_today.append(new_entry)
+
+            st_raw_tomorrow = state.attributes.get("raw_tomorrow")
+            if isinstance(st_raw_tomorrow, list):
+                if raw_tomorrow is None:
+                    raw_tomorrow = [e.copy() for e in st_raw_tomorrow if isinstance(e, dict)]
+                else:
+                    for idx, entry in enumerate(st_raw_tomorrow):
+                        if not isinstance(entry, dict) or "value" not in entry:
+                            continue
+                        try:
+                            add_val = float(entry["value"])
+                        except (ValueError, TypeError):
+                            continue
+                        if idx < len(raw_tomorrow):
+                            try:
+                                raw_tomorrow[idx]["value"] = float(raw_tomorrow[idx]["value"]) + add_val
+                            except (ValueError, TypeError, KeyError):
+                                raw_tomorrow[idx]["value"] = add_val
+                        else:
+                            new_entry = entry.copy()
+                            new_entry["value"] = add_val
+                            raw_tomorrow.append(new_entry)
         if not valid:
             self._attr_available = False
             return

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -572,3 +572,92 @@ async def test_current_price_attributes(hass: HomeAssistant):
 
     assert sensor.extra_state_attributes["net_prices_today"] == expected_today
     assert sensor.extra_state_attributes["net_prices_tomorrow"] == expected_tomorrow
+
+
+async def test_current_price_attributes_multiple_sensors(hass: HomeAssistant):
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Attr Price Multi",
+        "attrid_multi",
+        price_sensor=["sensor.price1", "sensor.price2"],
+        source_type=SOURCE_TYPE_CONSUMPTION,
+        price_settings={"vat_percentage": 0.0},
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("dec", "attr_multi")}),
+    )
+
+    raw_today_1 = [
+        {
+            "start": "2025-07-25T00:00:00+02:00",
+            "end": "2025-07-25T01:00:00+02:00",
+            "value": 0.1,
+        },
+        {
+            "start": "2025-07-25T01:00:00+02:00",
+            "end": "2025-07-25T02:00:00+02:00",
+            "value": 0.2,
+        },
+    ]
+    raw_today_2 = [
+        {
+            "start": "2025-07-25T00:00:00+02:00",
+            "end": "2025-07-25T01:00:00+02:00",
+            "value": 0.4,
+        },
+        {
+            "start": "2025-07-25T01:00:00+02:00",
+            "end": "2025-07-25T02:00:00+02:00",
+            "value": 0.5,
+        },
+    ]
+    raw_tomorrow_1 = [
+        {
+            "start": "2025-07-26T00:00:00+02:00",
+            "end": "2025-07-26T01:00:00+02:00",
+            "value": 0.3,
+        }
+    ]
+    raw_tomorrow_2 = [
+        {
+            "start": "2025-07-26T00:00:00+02:00",
+            "end": "2025-07-26T01:00:00+02:00",
+            "value": 0.6,
+        }
+    ]
+
+    hass.states.async_set(
+        "sensor.price1",
+        0.1,
+        {"raw_today": raw_today_1, "raw_tomorrow": raw_tomorrow_1},
+    )
+    hass.states.async_set(
+        "sensor.price2",
+        0.4,
+        {"raw_today": raw_today_2, "raw_tomorrow": raw_tomorrow_2},
+    )
+
+    await sensor.async_update()
+
+    expected_today = [
+        {
+            "start": raw_today_1[0]["start"],
+            "end": raw_today_1[0]["end"],
+            "value": 0.5,
+        },
+        {
+            "start": raw_today_1[1]["start"],
+            "end": raw_today_1[1]["end"],
+            "value": 0.7,
+        },
+    ]
+    expected_tomorrow = [
+        {
+            "start": raw_tomorrow_1[0]["start"],
+            "end": raw_tomorrow_1[0]["end"],
+            "value": 0.9,
+        }
+    ]
+
+    assert sensor.extra_state_attributes["net_prices_today"] == expected_today
+    assert sensor.extra_state_attributes["net_prices_tomorrow"] == expected_tomorrow
+    assert sensor.native_value == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- Sum raw price data from all configured sensors before converting to net prices
- Expand raw price conversion helper to support combined lists
- Test current price sensor with multiple sources providing raw price data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959a5c102c8323a4ac5e8db8ded559