### PR TITLE
Initialize daily cost sensors with current day value

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -205,10 +205,12 @@ class DailyElectricityCostSensor(BaseUtilitySensor):
         return round(total, 8)
 
     async def async_update(self):
-        pass
+        self._attr_native_value = self._calculate_daily_cost()
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
+        await self.async_update()
+        self.async_write_ha_state()
         self.async_on_remove(
             async_track_time_change(
                 self.hass,
@@ -272,10 +274,12 @@ class DailyGasCostSensor(BaseUtilitySensor):
         return round(total, 8)
 
     async def async_update(self):
-        pass
+        self._attr_native_value = self._calculate_daily_cost()
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
+        await self.async_update()
+        self.async_write_ha_state()
         self.async_on_remove(
             async_track_time_change(
                 self.hass,

--- a/tests/test_sensor_additional.py
+++ b/tests/test_sensor_additional.py
@@ -181,6 +181,38 @@ async def test_daily_cost_sensors(hass: HomeAssistant):
     assert g.native_value > 0
 
 
+async def test_daily_cost_sensors_initial_value(hass: HomeAssistant):
+    e = DailyElectricityCostSensor(
+        hass,
+        "E",
+        "eid",
+        {
+            "per_day_grid_operator_electricity_connection_fee": 0.1,
+            "vat_percentage": 0.0,
+        },
+        DeviceInfo(identifiers={("d", "1")}),
+    )
+    g = DailyGasCostSensor(
+        hass,
+        "G",
+        "gid",
+        {"per_day_supplier_gas_standing_charge": 0.2, "vat_percentage": 0.0},
+        DeviceInfo(identifiers={("d", "2")}),
+    )
+    e.async_write_ha_state = lambda *a, **k: None
+    g.async_write_ha_state = lambda *a, **k: None
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "custom_components.dynamic_energy_contract_calculator.sensor.async_track_time_change",
+            lambda *a, **k: "unsub",
+        )
+        await e.async_added_to_hass()
+        await g.async_added_to_hass()
+
+    assert e.native_value == pytest.approx(e._calculate_daily_cost())
+    assert g.native_value == pytest.approx(g._calculate_daily_cost())
+
+
 async def test_total_energy_cost_sensor_branches(hass: HomeAssistant):
     er_reg = er.async_get(hass)
     er_reg.async_get_or_create("sensor", DOMAIN, "net_uid", suggested_object_id="net")


### PR DESCRIPTION
## Summary
- ensure daily electricity and gas cost sensors compute their daily cost when added
- record daily cost immediately after installation
- test that daily cost sensors initialize with a daily value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959a5498ac8323aa50146bebe7fc65