### PR TITLE
Ensure source config replacement

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_contract_calculator/config_flow.py
@@ -107,12 +107,25 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
     async def async_step_select_sources(self, user_input=None) -> ConfigFlowResult:
         if user_input is not None:
             self.sources = user_input[CONF_SOURCES]
-            self.configs.append(
-                {
-                    CONF_SOURCE_TYPE: self.source_type,
-                    CONF_SOURCES: self.sources,
-                }
+
+            existing = next(
+                (
+                    config
+                    for config in self.configs
+                    if config[CONF_SOURCE_TYPE] == self.source_type
+                ),
+                None,
             )
+            if existing is not None:
+                existing[CONF_SOURCES] = self.sources
+            else:
+                self.configs.append(
+                    {
+                        CONF_SOURCE_TYPE: self.source_type,
+                        CONF_SOURCES: self.sources,
+                    }
+                )
+
             return await self.async_step_user()
 
         all_sensors = await self._get_energy_sensors()
@@ -278,12 +291,25 @@ class DynamicEnergyCalculatorOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_select_sources(self, user_input=None):
         if user_input and CONF_SOURCES in user_input:
             self.sources = user_input[CONF_SOURCES]
-            self.configs.append(
-                {
-                    CONF_SOURCE_TYPE: self.source_type,
-                    CONF_SOURCES: self.sources,
-                }
+
+            existing = next(
+                (
+                    config
+                    for config in self.configs
+                    if config[CONF_SOURCE_TYPE] == self.source_type
+                ),
+                None,
             )
+            if existing is not None:
+                existing[CONF_SOURCES] = self.sources
+            else:
+                self.configs.append(
+                    {
+                        CONF_SOURCE_TYPE: self.source_type,
+                        CONF_SOURCES: self.sources,
+                    }
+                )
+
             return await self.async_step_user()
 
         all_sensors = [

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -58,3 +58,39 @@ async def test_single_instance_abort(hass: HomeAssistant):
     result = await flow.async_step_user()
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_edit_source_replaces_existing_config(hass: HomeAssistant):
+    flow = DynamicEnergyCalculatorConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    async def _get_energy():
+        return ["sensor.energy", "sensor.energy_2"]
+
+    flow._get_energy_sensors = _get_energy
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION})
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_select_sources(
+        {CONF_SOURCES: ["sensor.energy"]}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION})
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_select_sources(
+        {CONF_SOURCES: ["sensor.energy_2"]}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: "finish"})
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_CONFIGS] == [
+        {
+            CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION,
+            CONF_SOURCES: ["sensor.energy_2"],
+        }
+    ]

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -68,3 +68,40 @@ async def test_options_flow_init_delegates(hass: HomeAssistant):
     flow.hass = hass
     result = await flow.async_step_init()
     assert result["type"] == FlowResultType.FORM
+
+
+async def test_options_flow_edit_source_replaces_existing_config(
+    hass: HomeAssistant,
+):
+    entry = MockConfigEntry(
+        domain="dynamic_energy_contract_calculator",
+        data={
+            CONF_CONFIGS: [
+                {
+                    CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION,
+                    CONF_SOURCES: ["sensor.energy"],
+                }
+            ]
+        },
+        entry_id="1",
+    )
+
+    flow = DynamicEnergyCalculatorOptionsFlowHandler(entry)
+    flow.hass = hass
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION})
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_select_sources(
+        {CONF_SOURCES: ["sensor.energy_2"]}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: "finish"})
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_CONFIGS] == [
+        {
+            CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION,
+            CONF_SOURCES: ["sensor.energy_2"],
+        }
+    ]


### PR DESCRIPTION
## Summary
- prevent duplicate source configs during configuration by updating existing entries
- verify replacement behavior for config and options flows

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a0515ce4c8323b53fea4d7d5bd4ba