### PR TITLE
Filter energy sensors by source type

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_contract_calculator/config_flow.py
@@ -26,7 +26,9 @@ STEP_SELECT_SOURCES = "select_sources"
 STEP_PRICE_SETTINGS = "price_settings"
 
 
-async def _get_energy_sensors(hass: HomeAssistant, source_type: str | None) -> list[str]:
+async def _get_energy_sensors(
+    hass: HomeAssistant, source_type: str | None
+) -> list[str]:
     """Return available energy or gas sensors with total state class."""
     device_class = "gas" if source_type == SOURCE_TYPE_GAS else "energy"
     return sorted(


### PR DESCRIPTION
## Summary
- Filter energy sensors by source type and state class
- Reuse sensor filtering in options flow
- Test helper for electricity and gas sensors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a19eed8088323aa5a2b8957226966