### PR TITLE
Fix GitHub Action error

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,5 +10,5 @@ async def set_time_zone(hass):
     os.environ["TZ"] = "America/Los_Angeles"
     if hasattr(time, "tzset"):
         time.tzset()
-    hass.config.set_time_zone("America/Los_Angeles")
+    await hass.config.async_set_time_zone("America/Los_Angeles")
     yield


### PR DESCRIPTION
Use the async version of set_time_zone to fix RuntimeError in pytest that requires async_set_time_zone for time zone configuration.

## 📝 What’s Changed?

<!-- Briefly describe the main changes in this PR -->
- ...

## 🔍 Why is this Change Needed?

<!-- Explain the reason or motivation behind the change -->
- ...

## 🧪 How Was This Tested?

<!-- Describe how you tested the changes -->
- [ ] Added or updated unit tests
- [ ] Manually tested in development environment
- [ ] CI/CD pipeline passed successfully

## ✅ Checklist

- [ ] Code follows the style guide
- [ ] All tests are passing
- [ ] Documentation updated if needed
- [ ] No breaking changes (or clearly documented)

## 📸 Screenshots / Logs (Optional)

<!-- Add any relevant UI screenshots or logs -->
_(e.g., Home Assistant UI, terminal output, etc.)_

## 📎 Additional Notes

<!-- Add anything else reviewers should know -->
- ...