### PR TITLE
fix: add credited energy tax to production value when netting

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -342,10 +342,15 @@ class DynamicEnergySensor(BaseUtilitySensor):
                         )
 
                 if self.mode == "profit_total" and self._netting_tracker is not None:
-                    # Record production for netting - tax balance is calculated dynamically
-                    await self._netting_tracker.async_record_production(  # type: ignore[union-attr]
+                    # Record production for netting and add credited tax to value
+                    (
+                        _credited_kwh,
+                        credited_value,
+                        _,
+                    ) = await self._netting_tracker.async_record_production(  # type: ignore[union-attr]
                         delta, tax * vat_factor
                     )
+                    adjusted_value += credited_value
             else:
                 _LOGGER.error("Unknown source_type: %s", self.source_type)
                 return


### PR DESCRIPTION
Production was only returning the base energy price without adding the credited energy tax from netting. This resulted in significantly lower values for feed-in when there was room to net against previous consumption.

## 📝 What’s Changed?

<!-- Briefly describe the main changes in this PR -->
- ...

## 🔍 Why is this Change Needed?

<!-- Explain the reason or motivation behind the change -->
- ...

## 🧪 How Was This Tested?

<!-- Describe how you tested the changes -->
- [ ] Added or updated unit tests
- [ ] Manually tested in development environment
- [ ] CI/CD pipeline passed successfully

## ✅ Checklist

- [ ] Code follows the style guide
- [ ] All tests are passing
- [ ] Documentation updated if needed
- [ ] No breaking changes (or clearly documented)

## 📸 Screenshots / Logs (Optional)

<!-- Add any relevant UI screenshots or logs -->
_(e.g., Home Assistant UI, terminal output, etc.)_

## 📎 Additional Notes

<!-- Add anything else reviewers should know -->
- ...