### PR TITLE
Add delivery price positive binary sensor

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -6,7 +6,7 @@ custom_components/dynamic_energy_contract_calculator/
   __init__.py       — config entry setup/unload, coordinator init
   config_flow.py    — UI setup wizard and options flow
   sensor.py         — cost/profit/kWh sensors (per source + summaries)
-  binary_sensor.py  — solar_bonus_active, production_price_positive
+  binary_sensor.py  — solar_bonus_active, production_price_positive, delivery_price_positive
   entity.py         — base entity with state restoration logic
   const.py          — all constants, config keys, supplier presets
   netting.py        — Dutch saldering (netting) calculation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Home Assistant custom integration (HACS) that calculates electricity and gas cos
   - `__init__.py` — setup, config entry load/unload
   - `config_flow.py` — UI setup and options flow
   - `sensor.py` — energy/cost/profit sensors
-  - `binary_sensor.py` — solar_bonus_active, production_price_positive
+  - `binary_sensor.py` — solar_bonus_active, production_price_positive, delivery_price_positive
   - `entity.py` — base entity with state restoration
   - `const.py` — constants, price keys, supplier presets
   - `netting.py` — Dutch saldering (netting) logic

--- a/custom_components/dynamic_energy_contract_calculator/__init__.py
+++ b/custom_components/dynamic_energy_contract_calculator/__init__.py
@@ -106,7 +106,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 continue
             uid = entity_entry.unique_id or ""
             for base_id, subentry_id in base_id_to_subentry.items():
-                if base_id in uid:
+                if uid.startswith(f"{DOMAIN}_{base_id}_"):
                     ent_reg.async_update_entity(
                         entity_entry.entity_id,
                         config_subentry_id=subentry_id,

--- a/custom_components/dynamic_energy_contract_calculator/binary_sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/binary_sensor.py
@@ -99,13 +99,13 @@ async def async_setup_entry(
             )
         )
 
-    if production_price_sensor:
+    if price_sensor_list:
         entities.append(
             DeliveryPricePositiveBinarySensor(
                 hass=hass,
                 unique_id=f"{entry.entry_id}_delivery_price_positive",
                 entry_id=entry.entry_id,
-                price_sensor=production_price_sensor,
+                price_sensors=price_sensor_list,
                 price_settings=price_settings,
                 device_info=device_info,
             )
@@ -260,7 +260,7 @@ class DeliveryPricePositiveBinarySensor(BinarySensorEntity):
         hass: HomeAssistant,
         unique_id: str,
         entry_id: str,
-        price_sensor: str | None,
+        price_sensors: list[str],
         price_settings: dict[str, Any],
         device_info: DeviceInfo,
     ):
@@ -270,17 +270,17 @@ class DeliveryPricePositiveBinarySensor(BinarySensorEntity):
         self._attr_has_entity_name = True
         self._attr_translation_key = "delivery_price_positive"
         self._attr_device_info = device_info
-        self._price_sensor = price_sensor
+        self._price_sensors = price_sensors
         self._price_settings = price_settings
         self._attr_is_on = False
 
     async def async_added_to_hass(self) -> None:
         """Register state change listener."""
-        if self._price_sensor:
+        if self._price_sensors:
             self.async_on_remove(
                 async_track_state_change_event(
                     self.hass,
-                    [self._price_sensor],
+                    self._price_sensors,
                     self._handle_price_change,
                 )
             )
@@ -294,21 +294,25 @@ class DeliveryPricePositiveBinarySensor(BinarySensorEntity):
         """Update the binary sensor state."""
         is_positive = False
 
-        if self._price_sensor:
-            price_state = self.hass.states.get(self._price_sensor)
-            if price_state and price_state.state not in ("unknown", "unavailable"):
-                try:
-                    base_price = float(price_state.state)
-                    markup = self._price_settings.get(
-                        "per_unit_supplier_electricity_markup", 0.0
-                    )
-                    tax = self._price_settings.get(
-                        "per_unit_government_electricity_tax", 0.0
-                    )
-                    total_price = base_price + markup + tax
-                    is_positive = total_price > 0
-                except (ValueError, TypeError):
-                    pass
+        if self._price_sensors:
+            total_price = 0.0
+            all_valid = False
+            for sensor_id in self._price_sensors:
+                price_state = self.hass.states.get(sensor_id)
+                if price_state and price_state.state not in ("unknown", "unavailable"):
+                    try:
+                        total_price += float(price_state.state)
+                        all_valid = True
+                    except (ValueError, TypeError):
+                        pass
+            if all_valid:
+                markup = self._price_settings.get(
+                    "per_unit_supplier_electricity_markup", 0.0
+                )
+                tax = self._price_settings.get(
+                    "per_unit_government_electricity_tax", 0.0
+                )
+                is_positive = (total_price + markup + tax) > 0
 
         self._attr_is_on = is_positive
         if self.entity_id:  # Only write state if entity is registered

--- a/custom_components/dynamic_energy_contract_calculator/binary_sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/binary_sensor.py
@@ -99,6 +99,18 @@ async def async_setup_entry(
             )
         )
 
+    if production_price_sensor:
+        entities.append(
+            DeliveryPricePositiveBinarySensor(
+                hass=hass,
+                unique_id=f"{entry.entry_id}_delivery_price_positive",
+                entry_id=entry.entry_id,
+                price_sensor=production_price_sensor,
+                price_settings=price_settings,
+                device_info=device_info,
+            )
+        )
+
     if entities:
         async_add_entities(entities)
 
@@ -231,6 +243,69 @@ class ProductionPricePositiveBinarySensor(BinarySensorEntity):
                         "per_unit_supplier_electricity_production_markup", 0.0
                     )
                     total_price = base_price + production_markup
+                    is_positive = total_price > 0
+                except (ValueError, TypeError):
+                    pass
+
+        self._attr_is_on = is_positive
+        if self.entity_id:  # Only write state if entity is registered
+            self.async_write_ha_state()
+
+
+class DeliveryPricePositiveBinarySensor(BinarySensorEntity):
+    """Binary sensor showing if delivery (consumption) price is positive."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        unique_id: str,
+        entry_id: str,
+        price_sensor: str | None,
+        price_settings: dict[str, Any],
+        device_info: DeviceInfo,
+    ):
+        """Initialize the binary sensor."""
+        self.hass = hass
+        self._attr_unique_id = unique_id
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "delivery_price_positive"
+        self._attr_device_info = device_info
+        self._price_sensor = price_sensor
+        self._price_settings = price_settings
+        self._attr_is_on = False
+
+    async def async_added_to_hass(self) -> None:
+        """Register state change listener."""
+        if self._price_sensor:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass,
+                    [self._price_sensor],
+                    self._handle_price_change,
+                )
+            )
+        await self._async_update_state()
+
+    async def _handle_price_change(self, event: Event[EventStateChangedData]) -> None:
+        """Handle price sensor state change."""
+        await self._async_update_state()
+
+    async def _async_update_state(self) -> None:
+        """Update the binary sensor state."""
+        is_positive = False
+
+        if self._price_sensor:
+            price_state = self.hass.states.get(self._price_sensor)
+            if price_state and price_state.state not in ("unknown", "unavailable"):
+                try:
+                    base_price = float(price_state.state)
+                    markup = self._price_settings.get(
+                        "per_unit_supplier_electricity_markup", 0.0
+                    )
+                    tax = self._price_settings.get(
+                        "per_unit_government_electricity_tax", 0.0
+                    )
+                    total_price = base_price + markup + tax
                     is_positive = total_price > 0
                 except (ValueError, TypeError):
                     pass

--- a/custom_components/dynamic_energy_contract_calculator/diagnostics.py
+++ b/custom_components/dynamic_energy_contract_calculator/diagnostics.py
@@ -64,6 +64,7 @@ async def async_get_config_entry_diagnostics(
         if state and (
             "solar_bonus_active" in state.entity_id.lower()
             or "production_price_positive" in state.entity_id.lower()
+            or "delivery_price_positive" in state.entity_id.lower()
         ):
             sensor_name = state.entity_id.replace("binary_sensor.", "")
             binary_sensors[sensor_name] = async_redact_data(

--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -121,6 +121,15 @@ class DynamicEnergySensor(BaseUtilitySensor):
             device=device,
             translation_key=mode,
         )
+        # TOTAL_INCREASING is used for all sensor modes, including cost/profit sensors.
+        # Rationale: on an unclean shutdown (power interrupt), the .storage/core.restore_state
+        # file can be corrupted, causing async_get_last_state() to return None and the
+        # sensor to start at 0. With TOTAL_INCREASING, HA's long-term statistics (LTS)
+        # recorder detects the drop as a "meter reset" and adds the previous accumulated
+        # value to its running sum, so the energy dashboard shows a continuous total.
+        # With TOTAL, a reset to 0 would be taken at face value and history would be lost.
+        # Trade-off: set_meter_value or tax adjustments that lower the value will also be
+        # interpreted as a reset by LTS, causing double-counting in statistics.
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self.hass = hass
         self.energy_sensor = energy_sensor

--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -1604,6 +1604,9 @@ async def async_setup_entry(
                 # Reset solar bonus tracker if present
                 if solar_bonus_tracker:
                     await solar_bonus_tracker.async_reset_year()
+                # Reset netting tracker if present
+                if netting_tracker:
+                    await netting_tracker.async_reset_all()
                 # Reset all utility entities for this entry
                 for entity in entities:
                     await entity.async_reset()

--- a/custom_components/dynamic_energy_contract_calculator/strings.json
+++ b/custom_components/dynamic_energy_contract_calculator/strings.json
@@ -220,6 +220,9 @@
       },
       "production_price_positive": {
         "name": "Production price positive"
+      },
+      "delivery_price_positive": {
+        "name": "Delivery price positive"
       }
     }
   }

--- a/custom_components/dynamic_energy_contract_calculator/translations/en.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/en.json
@@ -188,7 +188,8 @@
     },
     "binary_sensor": {
       "solar_bonus_active": {"name": "Solar Bonus Active"},
-      "production_price_positive": {"name": "Production Price Positive"}
+      "production_price_positive": {"name": "Production Price Positive"},
+      "delivery_price_positive": {"name": "Delivery Price Positive"}
     }
   },
     "issues": {

--- a/custom_components/dynamic_energy_contract_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/nl.json
@@ -220,6 +220,9 @@
       },
       "production_price_positive": {
         "name": "Terugleverprijs positief"
+      },
+      "delivery_price_positive": {
+        "name": "Leveringsprijs positief"
       }
     }
   },

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -422,7 +422,7 @@ async def test_delivery_price_positive_sensor(hass: HomeAssistant, device_info):
         hass=hass,
         unique_id="test_delivery_positive",
         entry_id="test_entry",
-        price_sensor="sensor.electricity_price",
+        price_sensors=["sensor.electricity_price"],
         price_settings=price_settings,
         device_info=device_info,
     )
@@ -455,7 +455,7 @@ async def test_delivery_price_positive_no_price_sensor(
         hass=hass,
         unique_id="test_delivery_no_sensor",
         entry_id="test_entry",
-        price_sensor=None,
+        price_sensors=[],
         price_settings={},
         device_info=device_info,
     )
@@ -471,7 +471,7 @@ async def test_delivery_price_positive_invalid_state(hass: HomeAssistant, device
         hass=hass,
         unique_id="test_delivery_invalid",
         entry_id="test_entry",
-        price_sensor="sensor.electricity_price",
+        price_sensors=["sensor.electricity_price"],
         price_settings={"per_unit_supplier_electricity_markup": 0.02},
         device_info=device_info,
     )
@@ -489,7 +489,7 @@ async def test_delivery_price_positive_entity_write_and_handler(
         hass=hass,
         unique_id="delivery-write",
         entry_id="test_entry",
-        price_sensor="sensor.electricity_price",
+        price_sensors=["sensor.electricity_price"],
         price_settings={},
         device_info=device_info,
     )

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from custom_components.dynamic_energy_contract_calculator.binary_sensor import (
     async_setup_entry,
+    DeliveryPricePositiveBinarySensor,
     SolarBonusActiveBinarySensor,
     ProductionPricePositiveBinarySensor,
 )
@@ -359,10 +360,11 @@ async def test_binary_sensor_setup_entry_creates_expected_entities(hass: HomeAss
 
     await async_setup_entry(hass, entry, add_entities)
 
-    assert len(added_entities) == 2
+    assert len(added_entities) == 3
     assert {entity.translation_key for entity in added_entities} == {
         "solar_bonus_active",
         "production_price_positive",
+        "delivery_price_positive",
     }
     assert "binary-setup" in hass.data[DOMAIN]["solar_bonus"]
 
@@ -405,6 +407,100 @@ async def test_binary_sensor_setup_entry_reuses_existing_tracker(hass: HomeAssis
 
     create_tracker.assert_not_called()
     assert added_entities[0]._solar_bonus_tracker is existing_tracker
+
+
+async def test_delivery_price_positive_sensor(hass: HomeAssistant, device_info):
+    """Test the delivery price positive binary sensor."""
+    hass.states.async_set("sensor.electricity_price", "0.10")
+
+    price_settings = {
+        "per_unit_supplier_electricity_markup": 0.02,
+        "per_unit_government_electricity_tax": 0.11,
+    }
+
+    sensor = DeliveryPricePositiveBinarySensor(
+        hass=hass,
+        unique_id="test_delivery_positive",
+        entry_id="test_entry",
+        price_sensor="sensor.electricity_price",
+        price_settings=price_settings,
+        device_info=device_info,
+    )
+
+    await sensor.async_added_to_hass()
+
+    # Should be ON (positive: 0.10 + 0.02 + 0.11 = 0.23)
+    assert sensor.is_on is True
+
+    # Change price to negative but still positive with markup+tax
+    hass.states.async_set("sensor.electricity_price", "-0.10")
+    await hass.async_block_till_done()
+
+    # Should be ON (positive: -0.10 + 0.02 + 0.11 = 0.03)
+    assert sensor.is_on is True
+
+    # Change price to very negative
+    hass.states.async_set("sensor.electricity_price", "-0.20")
+    await hass.async_block_till_done()
+
+    # Should be OFF (negative: -0.20 + 0.02 + 0.11 = -0.07)
+    assert sensor.is_on is False
+
+
+async def test_delivery_price_positive_no_price_sensor(
+    hass: HomeAssistant, device_info
+):
+    """Test delivery price positive sensor without price sensor."""
+    sensor = DeliveryPricePositiveBinarySensor(
+        hass=hass,
+        unique_id="test_delivery_no_sensor",
+        entry_id="test_entry",
+        price_sensor=None,
+        price_settings={},
+        device_info=device_info,
+    )
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.is_on is False
+
+
+async def test_delivery_price_positive_invalid_state(hass: HomeAssistant, device_info):
+    hass.states.async_set("sensor.electricity_price", "not-a-number")
+    sensor = DeliveryPricePositiveBinarySensor(
+        hass=hass,
+        unique_id="test_delivery_invalid",
+        entry_id="test_entry",
+        price_sensor="sensor.electricity_price",
+        price_settings={"per_unit_supplier_electricity_markup": 0.02},
+        device_info=device_info,
+    )
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.is_on is False
+
+
+async def test_delivery_price_positive_entity_write_and_handler(
+    hass: HomeAssistant, device_info
+):
+    hass.states.async_set("sensor.electricity_price", "bad")
+    sensor = DeliveryPricePositiveBinarySensor(
+        hass=hass,
+        unique_id="delivery-write",
+        entry_id="test_entry",
+        price_sensor="sensor.electricity_price",
+        price_settings={},
+        device_info=device_info,
+    )
+    sensor.entity_id = "binary_sensor.delivery_write"
+    writes = []
+    sensor.async_write_ha_state = lambda: writes.append("write")
+
+    await sensor._async_update_state()
+    await sensor._handle_price_change(type("Event", (), {"data": {}})())
+
+    assert writes == ["write", "write"]
 
 
 async def test_binary_sensor_setup_entry_without_matching_configuration(

--- a/tests/test_sensor_additional.py
+++ b/tests/test_sensor_additional.py
@@ -1280,6 +1280,9 @@ async def test_sensor_async_setup_entry_reuses_trackers_and_anniversary_callback
         async def async_reset_year(self):
             self.reset += 1
 
+        async def async_reset_all(self):
+            self.reset += 1
+
         def get_next_anniversary_date(self):
             return self.next_anniversary
 


### PR DESCRIPTION
## Summary
- Adds a binary sensor that indicates whether the current delivery price is positive
- Bugfixes follow-up commit included

## Test plan
- [ ] CI passes (lint, tests, hacs, hassfest)
- [ ] Binary sensor state toggles correctly based on delivery price sign