### PR TITLE
fix: credit netting production at historical FIFO tax rates

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/netting.py
+++ b/custom_components/dynamic_energy_contract_calculator/netting.py
@@ -233,7 +233,7 @@ class NettingTracker:
             Tuple of (taxable_kwh, taxable_value) - the portion that is taxable
             after applying netting rules.
         """
-        if delta_kwh <= 0 or tax_unit_price <= 0:
+        if delta_kwh <= 0:
             return 0.0, 0.0
 
         async with self._lock:
@@ -277,13 +277,15 @@ class NettingTracker:
 
         Args:
             delta_kwh: The production delta in kWh
-            tax_unit_price: The energy tax rate per kWh (used for return value)
+            tax_unit_price: The energy tax rate per kWh, used as fallback for
+                credited kWh not covered by recorded contributions (e.g., state
+                restored from storage without a contributions queue)
 
         Returns:
             Tuple of (credited_kwh, credited_value, sensor_adjustments).
             sensor_adjustments is always empty in this model.
         """
-        if delta_kwh <= 0 or tax_unit_price <= 0:
+        if delta_kwh <= 0:
             return 0.0, 0.0, []
 
         async with self._lock:
@@ -295,7 +297,11 @@ class NettingTracker:
 
             self._net_consumption_kwh = net_after
 
-            # Remove tax contributions in FIFO order for the credited kWh
+            # Remove tax contributions in FIFO order for the credited kWh.
+            # The credited value is derived from the removed contributions so
+            # the credit matches the tax that was actually charged, even if
+            # the tax rate or VAT changed since the consumption occurred.
+            credited_value = 0.0
             if credited_kwh > 0:
                 remaining_credit = credited_kwh
                 while remaining_credit > 0 and self._tax_contributions:
@@ -303,6 +309,7 @@ class NettingTracker:
                     if contrib.kwh <= remaining_credit:
                         # Remove entire contribution
                         remaining_credit -= contrib.kwh
+                        credited_value += contrib.tax_amount
                         self._tax_contributions.pop(0)
                         _LOGGER.debug(
                             "Removed tax contribution: %.4f kWh @ %.4f rate",
@@ -311,6 +318,9 @@ class NettingTracker:
                         )
                     else:
                         # Partial removal
+                        credited_value += (
+                            remaining_credit * contrib.tax_rate * contrib.vat_factor
+                        )
                         contrib.kwh = round(contrib.kwh - remaining_credit, 8)
                         _LOGGER.debug(
                             "Reduced tax contribution by %.4f kWh, %.4f kWh remaining",
@@ -318,9 +328,11 @@ class NettingTracker:
                             contrib.kwh,
                         )
                         remaining_credit = 0
-
-            # Calculate credited value using current rate (for return value only)
-            credited_value = round(credited_kwh * tax_unit_price, 8)
+                # Credited kWh not covered by the queue (legacy restored state):
+                # fall back to the current rate.
+                if remaining_credit > 0:
+                    credited_value += remaining_credit * tax_unit_price
+            credited_value = round(credited_value, 8)
 
             await self._async_save_state()
             return credited_kwh, credited_value, []

--- a/tests/test_netting.py
+++ b/tests/test_netting.py
@@ -144,8 +144,23 @@ async def test_netting_tracker_consumption_short_circuits_invalid_input(
     tracker = NettingTracker(hass, "entry-4", store, None, None)
 
     assert await tracker.async_record_consumption(None, 0.0, 0.1) == (0.0, 0.0)
-    assert await tracker.async_record_consumption(None, 1.0, 0.0) == (0.0, 0.0)
     store.async_save.assert_not_awaited()
+
+
+async def test_netting_tracker_consumption_tracks_net_with_zero_tax(
+    hass: HomeAssistant,
+) -> None:
+    """Net consumption is tracked even when the current tax rate is zero."""
+    store = AsyncMock()
+    tracker = NettingTracker(hass, "entry-4b", store, None, None)
+
+    taxable_kwh, taxable_value = await tracker.async_record_consumption(None, 1.0, 0.0)
+
+    assert taxable_kwh == pytest.approx(1.0)
+    assert taxable_value == 0.0
+    assert tracker.net_consumption_kwh == pytest.approx(1.0)
+    assert tracker.tax_balance == 0.0
+    store.async_save.assert_awaited_once()
 
 
 async def test_netting_tracker_records_production_fifo_credit(
@@ -170,12 +185,68 @@ async def test_netting_tracker_records_production_fifo_credit(
     )
 
     assert credited_kwh == pytest.approx(4.0)
-    assert credited_value == pytest.approx(0.5324)
+    # Credit is based on the historical rates of the removed contributions:
+    # 2.0 kWh @ 0.09 and 2.0 kWh @ 0.11, both with 21% VAT
+    assert credited_value == pytest.approx(2.0 * 0.09 * 1.21 + 2.0 * 0.11 * 1.21)
     assert adjustments == []
     assert tracker.net_consumption_kwh == pytest.approx(1.0)
     assert len(tracker._tax_contributions) == 1
     assert tracker._tax_contributions[0].kwh == pytest.approx(1.0)
     store.async_save.assert_awaited_once()
+
+
+async def test_netting_tracker_production_credit_uses_historical_rates(
+    hass: HomeAssistant,
+) -> None:
+    """Credit follows the FIFO contributions, not the current tax rate."""
+    store = AsyncMock()
+    tracker = NettingTracker(
+        hass,
+        "entry-5b",
+        store,
+        None,
+        # Current rate dropped to 0.05 after the consumption was taxed at 0.10
+        {"per_unit_government_electricity_tax": 0.05, "vat_percentage": 21.0},
+    )
+    tracker._net_consumption_kwh = 2.0
+    tracker._tax_contributions = [
+        TaxContribution(kwh=2.0, tax_rate=0.10, vat_factor=1.21),
+    ]
+
+    credited_kwh, credited_value, _ = await tracker.async_record_production(
+        1.0, 0.05 * 1.21
+    )
+
+    assert credited_kwh == pytest.approx(1.0)
+    # 1.0 kWh credited at the historical 0.10 rate, not the current 0.05
+    assert credited_value == pytest.approx(1.0 * 0.10 * 1.21)
+    assert tracker._tax_contributions[0].kwh == pytest.approx(1.0)
+
+
+async def test_netting_tracker_production_fallback_rate_for_uncovered_kwh(
+    hass: HomeAssistant,
+) -> None:
+    """Credited kWh beyond the contributions queue falls back to the current rate."""
+    store = AsyncMock()
+    tracker = NettingTracker(
+        hass,
+        "entry-5c",
+        store,
+        None,
+        {"per_unit_government_electricity_tax": 0.10, "vat_percentage": 21.0},
+    )
+    # Legacy state: positive net consumption without a contributions queue
+    tracker._net_consumption_kwh = 3.0
+    tracker._tax_contributions = [
+        TaxContribution(kwh=1.0, tax_rate=0.08, vat_factor=1.21),
+    ]
+
+    credited_kwh, credited_value, _ = await tracker.async_record_production(3.0, 0.121)
+
+    assert credited_kwh == pytest.approx(3.0)
+    # 1.0 kWh from the queue @ 0.08, remaining 2.0 kWh at the fallback rate
+    assert credited_value == pytest.approx(1.0 * 0.08 * 1.21 + 2.0 * 0.121)
+    assert tracker._tax_contributions == []
 
 
 async def test_netting_tracker_production_short_circuits_invalid_input(
@@ -185,8 +256,19 @@ async def test_netting_tracker_production_short_circuits_invalid_input(
     tracker = NettingTracker(hass, "entry-6", store, None, None)
 
     assert await tracker.async_record_production(0.0, 0.2) == (0.0, 0.0, [])
-    assert await tracker.async_record_production(1.0, 0.0) == (0.0, 0.0, [])
     store.async_save.assert_not_awaited()
+
+
+async def test_netting_tracker_production_tracks_net_with_zero_tax(
+    hass: HomeAssistant,
+) -> None:
+    """Net consumption is tracked even when the current tax rate is zero."""
+    store = AsyncMock()
+    tracker = NettingTracker(hass, "entry-6b", store, None, None)
+
+    assert await tracker.async_record_production(1.0, 0.0) == (0.0, 0.0, [])
+    assert tracker.net_consumption_kwh == pytest.approx(-1.0)
+    store.async_save.assert_awaited_once()
 
 
 async def test_netting_tracker_set_net_consumption_and_reset_all(


### PR DESCRIPTION
## Description

Found during an in-depth review of the calculation logic. Two related defects in `NettingTracker`:

1. **The production tax credit was calculated with the *current* tax rate** (`credited_value = credited_kwh * tax_unit_price`), while the FIFO contributions queue — which exists precisely to preserve the rate/VAT at consumption time (see the module docstring) — was drained without ever using its stored values. When the tax rate or VAT changes mid-contract, the credited amount does not match the tax that was actually charged. The credit is now derived from the removed FIFO contributions (`kwh × tax_rate × vat_factor` per contribution, including partial removals), with the current rate only as a fallback for credited kWh not covered by the queue (e.g., legacy restored state).

2. **The `tax_unit_price <= 0` guard skipped all state tracking**: with a (temporarily) zero tax rate, consumption no longer increased and production no longer decreased `net_consumption_kwh`, so the netting balance silently diverged from the actual energy flows. Both methods now always update the balance; only `delta_kwh <= 0` short-circuits.

`test_netting_tracker_records_production_fifo_credit` encoded the old behaviour (credit at the current 0.1331 rate despite historical 0.09/0.11 contributions) and has been updated; new tests cover the historical-rate credit, the fallback for uncovered kWh, and zero-tax tracking.

## Impact on running installations

**Who is affected:** only installations with `netting_enabled: true` (e.g., the Zonneplan preset). Installations without netting are untouched.

**Storage / migration:** none needed. The persisted netting state (`.storage/dynamic_energy_contract_calculator_netting_<entry_id>`) keeps the same version and format; the contributions queue was already being written, it just wasn't read for the credit. Existing state loads unchanged.

**Behavioural change after update:**
- Installations that have run with a **constant tax rate and VAT** (the vast majority): the FIFO rates in the queue equal the current rate, so future credits are **numerically identical** to before — no visible change.
- Installations where the tax rate/VAT **was changed mid-contract**: future credits will differ (correctly) from the old calculation. Past mis-credits are **not** retroactively corrected — cost/profit sensors are cumulative meters and are not recalculated; only credits booked after the update use the historical rates.
- Restored state where `net_consumption_kwh > 0` but the queue is empty or shorter (pre-queue installs): the fallback reproduces the old current-rate behaviour, so nothing degrades.
- Zero-tax configurations: the net balance now tracks flows where it previously froze. If such an installation built up a skewed balance, a one-time correction via the `set_netting_value` service is possible, but not required.

**Entities / statistics:** no entity IDs, unique IDs, state classes or attributes change; profit sensors remain `TOTAL_INCREASING` and only ever receive non-negative credit additions, so HA long-term statistics are unaffected. A normal HACS update + restart is sufficient.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [ ] Documentation updated if needed
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Full test suite passes locally (`python -m pytest tests/`, 206 passed); `ruff check` and `ruff format --check` clean on the changed files.