### PR TITLE
fix: keep energy delta pending while price sensors are unavailable

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -229,7 +229,12 @@ class DynamicEnergySensor(BaseUtilitySensor):
         if self._last_energy is not None:
             delta = current_energy - self._last_energy
             if delta < 0:
+                # Meter reset: re-baseline so future deltas are measured from
+                # the new meter value.
                 delta = 0.0
+                self._last_energy = current_energy
+        else:
+            self._last_energy = current_energy
 
         _LOGGER.debug(
             "Current energy=%s, Last energy=%s, Delta=%s",
@@ -237,8 +242,6 @@ class DynamicEnergySensor(BaseUtilitySensor):
             self._last_energy,
             delta,
         )
-
-        self._last_energy = current_energy
 
         if self.mode not in ("kwh_total", "m3_total") and not self.price_sensors:
             _LOGGER.debug(
@@ -249,6 +252,7 @@ class DynamicEnergySensor(BaseUtilitySensor):
 
         if self.mode in ("kwh_total", "m3_total"):
             self._attr_native_value += delta
+            self._last_energy = current_energy
         elif self.price_sensors:
             total_price = 0.0
             valid = False
@@ -287,6 +291,11 @@ class DynamicEnergySensor(BaseUtilitySensor):
                 async_clear_issue(self.hass, f"price_unavailable_{self.price_sensor}")
                 async_clear_issue(self.hass, f"price_invalid_{self.price_sensor}")
                 self._price_unavailable_since = None
+
+            # The delta is consumed below; only advance the baseline now so
+            # that the early return above (no valid price) keeps the delta
+            # pending until the price sensors recover instead of dropping it.
+            self._last_energy = current_energy
 
             adjusted_value = None
             taxable_value = 0.0

--- a/tests/test_entity_edge_cases.py
+++ b/tests/test_entity_edge_cases.py
@@ -111,6 +111,58 @@ async def test_price_unavailable(hass: HomeAssistant):
     assert not sensor.available
 
 
+async def test_delta_kept_pending_while_price_unavailable(hass: HomeAssistant):
+    """Energy consumed during a price outage is priced once the price recovers."""
+    sensor = await _make_sensor(
+        hass,
+        price_settings={
+            "per_unit_supplier_electricity_markup": 0.0,
+            "per_unit_government_electricity_tax": 0.0,
+            "vat_percentage": 0.0,
+        },
+    )
+    sensor._last_energy = 0
+    hass.states.async_set("sensor.energy", 1)
+    hass.states.async_set("sensor.price", "unavailable")
+    await sensor.async_update()
+    # Delta of 1 kWh is pending, not dropped
+    assert sensor._last_energy == 0
+    assert sensor.native_value == 0.0
+
+    hass.states.async_set("sensor.energy", 2)
+    hass.states.async_set("sensor.price", 0.5)
+    await sensor.async_update()
+    # Full 2 kWh since the baseline is priced on recovery
+    assert sensor._last_energy == 2
+    assert sensor.native_value == pytest.approx(1.0)
+
+
+async def test_meter_reset_rebaselines_even_when_price_unavailable(
+    hass: HomeAssistant,
+):
+    """A meter reset re-baselines immediately so no phantom delta is created."""
+    sensor = await _make_sensor(
+        hass,
+        price_settings={
+            "per_unit_supplier_electricity_markup": 0.0,
+            "per_unit_government_electricity_tax": 0.0,
+            "vat_percentage": 0.0,
+        },
+    )
+    sensor._last_energy = 10
+    hass.states.async_set("sensor.energy", 2)
+    hass.states.async_set("sensor.price", "unavailable")
+    await sensor.async_update()
+    # Baseline follows the reset meter value
+    assert sensor._last_energy == 2
+
+    hass.states.async_set("sensor.energy", 3)
+    hass.states.async_set("sensor.price", 0.5)
+    await sensor.async_update()
+    # Only the 1 kWh after the reset is priced
+    assert sensor.native_value == pytest.approx(0.5)
+
+
 async def test_price_invalid(hass: HomeAssistant):
     sensor = await _make_sensor(hass)
     sensor._last_energy = 0


### PR DESCRIPTION
## Description

Found during an in-depth review of the calculation logic. In `DynamicEnergySensor.async_update`, the energy baseline `_last_energy` was advanced to the current meter reading *before* the price sensors were validated. When all price sensors were unavailable or invalid, the method returned early — and the energy consumed since the previous update was permanently dropped from the `cost_total`, `profit_total` and `kwh_during_*` meters. During a longer price-sensor outage (integration down, network issue), all consumption/production in that window was silently never priced.

The baseline is now only advanced once the delta is actually consumed:

- immediately for the pure `kwh_total`/`m3_total` counters (unchanged behaviour),
- after price validation for the priced modes, so during a price outage the delta stays pending and is priced when the sensors recover (at the then-current price — the same approximation the integration already makes within one price interval),
- a negative delta (source meter reset) still re-baselines immediately, so no phantom delta can accumulate across a reset.

New tests cover delta retention across a price outage and re-baselining on a meter reset while prices are unavailable.

## Impact on running installations

**Who is affected:** all installations with a price sensor configured (i.e., any install with cost/profit sensors). Pure kWh/m³ counters behave exactly as before.

**Storage / migration:** none. `_last_energy` is an in-memory value that is not persisted; nothing in `.storage` changes format.

**Behavioural change after update:**
- In normal operation (price sensors available) the booked amounts are **numerically identical** to before.
- After a price-sensor outage, the cost/profit and `kwh_during_*` meters will now show a **single catch-up step** at recovery, covering the energy consumed during the outage priced at the recovery price. Previously that energy was silently omitted, so totals will be slightly *higher* (more correct) than users may be used to after outages.
- Since the sensors are `TOTAL_INCREASING` and the catch-up is always an increase, HA long-term statistics handle it as a regular rise — no reset detection, no spikes beyond the genuine catch-up amount.
- Restart behaviour is unchanged: `_last_energy` starts empty after a restart, so energy consumed while HA was down is still not priced (same as before this PR).
- A source-meter reset during a price outage now re-baselines correctly; previously this case could not occur separately (the baseline always advanced), so no installation regresses here.

**Entities / statistics:** no entity IDs, unique IDs, state classes or attributes change. No user action required; a normal HACS update + restart is sufficient.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [ ] Documentation updated if needed
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Full test suite passes locally (`python -m pytest tests/`, 207 passed); `ruff check` and `ruff format --check` clean on the changed files.