### PR TITLE
fix: do not fold netting credit and solar bonus into the energy value sign

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -290,6 +290,11 @@ class DynamicEnergySensor(BaseUtilitySensor):
 
             adjusted_value = None
             taxable_value = 0.0
+            # Solar bonus and netting tax credit for production. Kept separate
+            # from adjusted_value: the sign of adjusted_value decides whether
+            # the energy itself is cost or profit, while these credits are
+            # always earned and always belong to the profit sensor.
+            bonus_and_credit = 0.0
 
             if self.source_type == SOURCE_TYPE_GAS:
                 unit_price = (total_price + markup_consumption + tax) * vat_factor
@@ -348,7 +353,7 @@ class DynamicEnergySensor(BaseUtilitySensor):
                     )
 
                     if solar_bonus_amount > 0:
-                        adjusted_value += solar_bonus_amount
+                        bonus_and_credit += solar_bonus_amount
                         _LOGGER.debug(
                             "Solar bonus: %.2f kWh eligible, %.4f EUR bonus added",
                             eligible_kwh,
@@ -364,7 +369,7 @@ class DynamicEnergySensor(BaseUtilitySensor):
                     ) = await self._netting_tracker.async_record_production(
                         delta, tax * vat_factor
                     )
-                    adjusted_value += credited_value
+                    bonus_and_credit += credited_value
             else:
                 _LOGGER.error("Unknown source_type: %s", self.source_type)
                 return
@@ -410,6 +415,11 @@ class DynamicEnergySensor(BaseUtilitySensor):
                 elif self.source_type == SOURCE_TYPE_PRODUCTION:
                     if adjusted_value >= 0:
                         self._attr_native_value += adjusted_value
+                    # Bonus and netting credit are earned regardless of the
+                    # sign of the energy value itself. A negative energy value
+                    # is already booked on the cost sensor; folding the credit
+                    # into it here would double count that negative value.
+                    self._attr_native_value += bonus_and_credit
             elif self.mode == "kwh_during_cost_total":
                 if self.source_type in (SOURCE_TYPE_CONSUMPTION, SOURCE_TYPE_GAS):
                     if adjusted_value >= 0:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -500,6 +500,67 @@ async def test_netting_applies_tax_credit(hass: HomeAssistant):
     assert production.native_value == pytest.approx(0.121, rel=1e-6)
 
 
+async def test_netting_credit_with_negative_production_price(hass: HomeAssistant):
+    """Netting tax credit is not swallowed by a negative production price.
+
+    The negative energy value is booked on the production cost sensor; the
+    tax credit must land on the profit sensor in full. If the credit were
+    folded into the (negative) energy value, the negative value would be
+    counted twice in the net total (cost - profit).
+    """
+    price_settings = {
+        "per_unit_supplier_electricity_markup": 0.0,
+        "per_unit_supplier_electricity_production_markup": 0.0,
+        "per_unit_government_electricity_tax": 0.1,
+        "vat_percentage": 21.0,
+        "production_price_include_vat": True,
+    }
+    tracker = await NettingTracker.async_create(
+        hass, "entry_netting_negative_price", price_settings
+    )
+    await tracker.async_reset_all()
+    # 1 kWh taxed consumption to be netted against
+    await tracker.async_record_consumption(None, 1.0, 0.1 * 1.21)
+
+    cost_sensor = DynamicEnergySensor(
+        hass,
+        "Production Cost",
+        "production_cost_neg",
+        "sensor.production_energy",
+        SOURCE_TYPE_PRODUCTION,
+        price_settings,
+        price_sensor="sensor.price",
+        mode="cost_total",
+        netting_tracker=tracker,
+    )
+    profit_sensor = DynamicEnergySensor(
+        hass,
+        "Production Profit",
+        "production_profit_neg",
+        "sensor.production_energy",
+        SOURCE_TYPE_PRODUCTION,
+        price_settings,
+        price_sensor="sensor.price",
+        mode="profit_total",
+        netting_tracker=tracker,
+    )
+    cost_sensor.async_write_ha_state = lambda *args, **kwargs: None
+    profit_sensor.async_write_ha_state = lambda *args, **kwargs: None
+
+    cost_sensor._last_energy = 0.0
+    profit_sensor._last_energy = 0.0
+    hass.states.async_set("sensor.production_energy", 1.0)
+    hass.states.async_set("sensor.price", -0.2)
+    await cost_sensor.async_update()
+    await profit_sensor.async_update()
+
+    # Energy value: 1 kWh * -0.2 * 1.21 = -0.242 booked as cost
+    assert cost_sensor.native_value == pytest.approx(0.242, rel=1e-6)
+    # Tax credit for the netted kWh (0.1 * 1.21) lands on profit in full
+    assert profit_sensor.native_value == pytest.approx(0.121, rel=1e-6)
+    assert tracker.net_consumption_kwh == pytest.approx(0.0, abs=1e-6)
+
+
 async def test_summary_sensor_netting_attributes(hass: HomeAssistant):
     price_settings = {
         "per_unit_supplier_electricity_markup": 0.0,


### PR DESCRIPTION
## Description

Found during an in-depth review of the calculation logic. For production, the netting tax credit and solar bonus were added into `adjusted_value` **before** its sign decided whether the update is booked as cost or profit. With a **negative production price** and netting enabled this double counts:

- the production **cost sensor** books the negative energy value (e.g., 1 kWh × −0.20 × 1.21 = €0.242 cost), and
- on the **profit sensor** the tax credit (e.g., €0.121) was netted against that *same* negative value: `−0.242 + 0.121 = −0.121 < 0` → nothing booked, credit lost entirely; with a larger credit only the remainder was booked.

Either way, the net total (`cost − profit`) counted the negative energy value twice, and the tax credit the user is entitled to under saldering (independent of the spot price) could disappear.

The credit and bonus are now accumulated separately (`bonus_and_credit`) and always added to the profit sensor, while the sign of the plain energy value keeps deciding the cost/profit split. For positive prices the booked amounts are identical to before (all existing tests unchanged and green). The solar bonus is only granted when the compensation is positive, so it could not flip the sign by itself, but it is moved along for consistency.

New regression test: negative production price with an outstanding netting balance → cost sensor books €0.242, profit sensor books the full €0.121 credit.

## Impact on running installations

**Who is affected:** only installations with **netting enabled on production** (e.g., the Zonneplan preset), and only during hours where the total production compensation (spot + production markup) is **negative**. Installations without netting, and all positive-price hours, book exactly the same amounts as before.

**Storage / migration:** none. The netting storage format is untouched; `net_consumption_kwh` and the contributions queue were already updated correctly — only the booking of the returned credit on the profit sensor changes.

**Behavioural change after update:**
- During negative-price hours with a **positive netting balance**, the production **profit sensor** will now increase by the full tax credit where it previously increased by less (or not at all). The **cost sensor** is unchanged. Net cost (`cost − profit`) therefore comes out **lower (correct)** during those hours than under the old behaviour.
- Note: whether a credit exists at all is unchanged and decided by the tracker (`credited_kwh = max(net_before, 0) − max(net_after, 0)`). With a **zero or negative netting balance no tax was ever charged, so no credit is granted** — before and after this PR. Only the portion of production that reduces a positive balance is credited; this PR only changes *where* an already-granted credit is booked.
- Historical values are **not** retroactively corrected: cost/profit sensors are cumulative meters. Credits that were swallowed in past negative-price hours remain missing from the totals; users who want to compensate can do a one-time adjustment via the `set_meter_value` service, but this is optional.
- The profit sensor is `TOTAL_INCREASING` and the change only ever *adds* a non-negative amount, so HA long-term statistics see a normal increase — no reset detection or spikes.

**Entities / statistics:** no entity IDs, unique IDs, state classes or attributes change. No user action required; a normal HACS update + restart is sufficient.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [ ] Documentation updated if needed
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Full test suite passes locally (`python -m pytest tests/`, 206 passed); `ruff check` and `ruff format --check` clean on the changed files.