### PR TITLE
fix: pay out untaxed netted consumption on the base price instead of gross

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -159,6 +159,14 @@ class DynamicEnergySensor(BaseUtilitySensor):
             and self.mode == "cost_total"
         )
 
+    @property
+    def _uses_netting_profit(self) -> bool:
+        return (
+            self._netting_tracker is not None
+            and self.source_type == SOURCE_TYPE_CONSUMPTION
+            and self.mode == "profit_total"
+        )
+
     async def async_update(self) -> None:
         _LOGGER.debug(
             "Updating %s (mode=%s) using %s",
@@ -326,6 +334,23 @@ class DynamicEnergySensor(BaseUtilitySensor):
                         self, delta, tax_unit_price
                     )
                     adjusted_value = base_value + taxable_value
+                    if adjusted_value < 0:
+                        # A negative netted value is a payout; the cost sensor
+                        # cannot book it, so hand it to the profit sensor of
+                        # the same energy source via the tracker.
+                        await netting_tracker.async_add_pending_profit(
+                            self.energy_sensor, -adjusted_value
+                        )
+                elif self._uses_netting_profit:
+                    netting_tracker = self._netting_tracker
+                    assert netting_tracker is not None
+                    # With netting, the consumption profit comes from the
+                    # netted value handed off by the cost sensor. The gross
+                    # price would wrongly include energy tax that netting
+                    # does not charge while the balance is negative.
+                    adjusted_value = -await netting_tracker.async_claim_pending_profit(
+                        self.energy_sensor
+                    )
                 else:
                     adjusted_value = value
             elif self.source_type == SOURCE_TYPE_PRODUCTION:

--- a/custom_components/dynamic_energy_contract_calculator/netting.py
+++ b/custom_components/dynamic_energy_contract_calculator/netting.py
@@ -91,11 +91,24 @@ class NettingTracker:
         self._tax_contributions: list[TaxContribution] = []
         self._sensors: dict[str, DynamicEnergySensor] = {}
         self._price_settings = price_settings or {}
+        # Negative netted consumption values handed off by the cost sensor,
+        # keyed by energy source entity_id, awaiting pickup by the matching
+        # profit sensor.
+        self._pending_profit: dict[str, float] = {}
 
         if initial_state:
             self._net_consumption_kwh = float(
                 initial_state.get("net_consumption_kwh", 0.0)
             )
+            pending = initial_state.get("pending_consumption_profit", {})
+            if isinstance(pending, dict):
+                for source_id, amount in pending.items():
+                    try:
+                        value = float(amount)
+                    except (TypeError, ValueError):
+                        continue
+                    if value > 0:
+                        self._pending_profit[str(source_id)] = value
             # Restore tax contributions from storage
             contributions_data = initial_state.get("tax_contributions", [])
             if isinstance(contributions_data, list):
@@ -337,11 +350,35 @@ class NettingTracker:
             await self._async_save_state()
             return credited_kwh, credited_value, []
 
+    async def async_add_pending_profit(self, source_id: str, amount: float) -> None:
+        """Hand off a negative netted consumption value to the profit sensor.
+
+        When netting makes the consumption value negative (a payout), the
+        cost sensor cannot book it. The amount is parked here, keyed by the
+        energy source, until the matching profit sensor claims it.
+        """
+        if amount <= 0:
+            return
+        async with self._lock:
+            self._pending_profit[source_id] = round(
+                self._pending_profit.get(source_id, 0.0) + amount, 8
+            )
+            await self._async_save_state()
+
+    async def async_claim_pending_profit(self, source_id: str) -> float:
+        """Return and clear the pending profit for the given energy source."""
+        async with self._lock:
+            amount = self._pending_profit.pop(source_id, 0.0)
+            if amount:
+                await self._async_save_state()
+            return amount
+
     async def async_reset_all(self) -> None:
         """Reset the entire tracker state."""
         async with self._lock:
             self._net_consumption_kwh = 0.0
             self._tax_contributions.clear()
+            self._pending_profit.clear()
             await self._async_save_state()
             _LOGGER.info(
                 "Netting tracker reset: net_consumption_kwh=0.0, contributions cleared"
@@ -381,5 +418,9 @@ class NettingTracker:
         data = {
             "net_consumption_kwh": round(self._net_consumption_kwh, 8),
             "tax_contributions": [c.to_dict() for c in self._tax_contributions],
+            "pending_consumption_profit": {
+                source_id: round(amount, 8)
+                for source_id, amount in self._pending_profit.items()
+            },
         }
         await self._store.async_save(data)

--- a/tests/test_netting.py
+++ b/tests/test_netting.py
@@ -133,6 +133,7 @@ async def test_netting_tracker_records_consumption_and_saves(
         {
             "net_consumption_kwh": 2.0,
             "tax_contributions": [{"kwh": 2.0, "tax_rate": 0.11, "vat_factor": 1.21}],
+            "pending_consumption_profit": {},
         }
     )
 
@@ -295,6 +296,63 @@ async def test_netting_tracker_set_net_consumption_and_reset_all(
     assert tracker.net_consumption_kwh == 0.0
     assert tracker._tax_contributions == []
     assert store.async_save.await_count == 3
+
+
+async def test_netting_tracker_pending_profit_add_claim_and_reset(
+    hass: HomeAssistant,
+) -> None:
+    store = AsyncMock()
+    tracker = NettingTracker(hass, "entry-pending", store, None, None)
+
+    # Non-positive amounts are ignored
+    await tracker.async_add_pending_profit("sensor.energy", 0.0)
+    await tracker.async_add_pending_profit("sensor.energy", -1.0)
+    store.async_save.assert_not_awaited()
+
+    # Claiming with nothing pending returns 0 and does not persist
+    assert await tracker.async_claim_pending_profit("sensor.energy") == 0.0
+    store.async_save.assert_not_awaited()
+
+    # Amounts accumulate per energy source until claimed
+    await tracker.async_add_pending_profit("sensor.energy", 0.05)
+    await tracker.async_add_pending_profit("sensor.energy", 0.02)
+    await tracker.async_add_pending_profit("sensor.other", 0.10)
+    assert await tracker.async_claim_pending_profit("sensor.energy") == pytest.approx(
+        0.07
+    )
+    assert await tracker.async_claim_pending_profit("sensor.energy") == 0.0
+    assert await tracker.async_claim_pending_profit("sensor.other") == pytest.approx(
+        0.10
+    )
+
+    # Reset clears any pending amounts
+    await tracker.async_add_pending_profit("sensor.energy", 0.03)
+    await tracker.async_reset_all()
+    assert await tracker.async_claim_pending_profit("sensor.energy") == 0.0
+
+
+async def test_netting_tracker_restores_pending_profit(hass: HomeAssistant) -> None:
+    store = AsyncMock()
+    tracker = NettingTracker(
+        hass,
+        "entry-pending-restore",
+        store,
+        {
+            "net_consumption_kwh": -2.0,
+            "pending_consumption_profit": {
+                "sensor.energy": 0.05,
+                "sensor.bad": "invalid",
+                "sensor.zero": 0.0,
+            },
+        },
+        None,
+    )
+
+    assert await tracker.async_claim_pending_profit("sensor.energy") == pytest.approx(
+        0.05
+    )
+    assert await tracker.async_claim_pending_profit("sensor.bad") == 0.0
+    assert await tracker.async_claim_pending_profit("sensor.zero") == 0.0
 
 
 async def test_netting_tracker_production_drains_entire_queue(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -561,6 +561,69 @@ async def test_netting_credit_with_negative_production_price(hass: HomeAssistant
     assert tracker.net_consumption_kwh == pytest.approx(0.0, abs=1e-6)
 
 
+async def test_netting_consumption_profit_uses_netted_value(hass: HomeAssistant):
+    """Consumption during a negative netting balance is paid out on the base price.
+
+    With a negative balance the energy tax is not charged, so a negative base
+    price must be paid out in full. Previously the profit sensor used the
+    gross price (including tax), which swallowed the payout partly or wholly.
+    """
+    price_settings = {
+        "per_unit_supplier_electricity_markup": 0.0,
+        "per_unit_government_electricity_tax": 0.1,
+        "vat_percentage": 21.0,
+    }
+    tracker = await NettingTracker.async_create(
+        hass, "entry_netting_consumption_profit", price_settings
+    )
+    await tracker.async_reset_all()
+    # Summer surplus: negative netting balance, so consumption is untaxed
+    await tracker.async_set_net_consumption(-5.0)
+
+    cost_sensor = DynamicEnergySensor(
+        hass,
+        "Consumption Cost",
+        "consumption_cost_pending",
+        "sensor.consumption_energy",
+        SOURCE_TYPE_CONSUMPTION,
+        price_settings,
+        price_sensor="sensor.price",
+        mode="cost_total",
+        netting_tracker=tracker,
+    )
+    profit_sensor = DynamicEnergySensor(
+        hass,
+        "Consumption Profit",
+        "consumption_profit_pending",
+        "sensor.consumption_energy",
+        SOURCE_TYPE_CONSUMPTION,
+        price_settings,
+        price_sensor="sensor.price",
+        mode="profit_total",
+        netting_tracker=tracker,
+    )
+    cost_sensor.async_write_ha_state = lambda *args, **kwargs: None
+    profit_sensor.async_write_ha_state = lambda *args, **kwargs: None
+
+    # Negative price, but gross (incl. tax) would be positive:
+    # base = -0.05 * 1.21 = -0.0605, gross = (-0.05 + 0.1) * 1.21 = +0.0605
+    cost_sensor._last_energy = 0.0
+    profit_sensor._last_energy = 0.0
+    hass.states.async_set("sensor.consumption_energy", 1.0)
+    hass.states.async_set("sensor.price", -0.05)
+    await cost_sensor.async_update()
+    await profit_sensor.async_update()
+
+    # Untaxed consumption at a negative price is a payout on the base price
+    assert cost_sensor.native_value == pytest.approx(0.0, abs=1e-9)
+    assert profit_sensor.native_value == pytest.approx(0.0605, rel=1e-6)
+    assert tracker.net_consumption_kwh == pytest.approx(-4.0, rel=1e-6)
+
+    # A second claim without new consumption books nothing extra
+    await profit_sensor.async_update()
+    assert profit_sensor.native_value == pytest.approx(0.0605, rel=1e-6)
+
+
 async def test_summary_sensor_netting_attributes(hass: HomeAssistant):
     price_settings = {
         "per_unit_supplier_electricity_markup": 0.0,


### PR DESCRIPTION
## Description

Follow-up from the calculation review (see #148/#149/#150). With netting enabled, the consumption **cost** sensor books the netted value — base price, plus energy tax only for the portion of the delta above a zero balance. The consumption **profit** sensor however always used the **gross** price *including tax*, regardless of the netting state.

While the netting balance is negative (a summer surplus being consumed, e.g. charging an EV during negative midday prices), energy tax is not charged, so a negative base price must be paid out in full. Because the gross price includes the tax, the payout was swallowed partly or completely:

- base −0.05/kWh, tax 0.121/kWh → gross +0.071: cost sensor books nothing (netted value negative), profit sensor books nothing (gross positive) → the €0.0605 payout for 1 kWh disappears entirely;
- base −0.20/kWh → gross −0.079: profit sensor books €0.079 instead of the full €0.242 — the tax was effectively still charged even though netting exempts it.

**Fix:** the netting-aware cost sensor already computes the exact netted value. When that value is negative, it is now handed off through the tracker (`async_add_pending_profit`, persisted in the netting store keyed by energy source) and claimed by the matching profit sensor of the same source (`async_claim_pending_profit`), which no longer prices from gross when netting is enabled. This is exact regardless of the update order of the two sensor entities: if the profit sensor happens to run first within an event, it books the amount on its next update.

With a **positive** balance the netted value equals gross, so all bookings are identical to before; installations without netting are untouched. New tests cover the hand-off/claim/persistence in the tracker and the end-to-end negative-balance + negative-price scenario.

## Impact on running installations

**Who is affected:** only installations with `netting_enabled: true`, and only during hours where consumption occurs at a **negative base price** while the **netting balance is negative or crosses below zero**. All other situations book byte-identical amounts.

**Storage / migration:** the netting store gains one key (`pending_consumption_profit`); the storage version stays 1. Old state files load unchanged (the key defaults to empty), and a rollback to an older version simply ignores the key — no migration needed either way.

**Behavioural change after update:**
- In the affected hours the consumption **profit sensor** will book the full payout on the base price where it previously booked a reduced amount or nothing. Net cost (`cost − profit`) comes out lower (correct) in those hours.
- Historical totals are **not** retroactively corrected; payouts swallowed in the past remain missing. An optional one-time correction is possible via `set_meter_value`.
- The profit sensor is `TOTAL_INCREASING` and only receives additional non-negative amounts, so HA long-term statistics see a normal increase — no reset detection.
- Pending amounts survive restarts via the netting store. If a user has disabled the consumption profit entity in the registry, amounts accumulate unclaimed in storage (harmless; claimed on re-enable). `reset_all_meters` / contract-anniversary reset also clears pending amounts.

**Entities / statistics:** no entity IDs, unique IDs, state classes or attributes change. A normal HACS update + restart is sufficient.

**Known remaining limitation (out of scope):** the informational `kwh_during_cost_total`/`kwh_during_profit_total` counters for consumption still classify on the gross price; only the money sensors are corrected here.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable
- [ ] Documentation updated if needed
- [ ] CI is green
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

Full test suite passes locally (`python -m pytest tests/`, 200 passed); `ruff check` and `ruff format --check` clean on the changed files.