### PR TITLE
ci: test against Python 3.14, cover main, and rework the release trigger

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.3.6"
+current_version = "2.0.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,15 @@ jobs:
       # Addressed as a module, with the same package flags the hook uses:
       # passing the directory makes mypy see __init__.py under two module
       # names and stop before checking anything.
+      # --python-version overrides the 3.13 target in setup.cfg, which the
+      # pre-commit hook keeps: that hook reads .pyi stubs, but this step
+      # parses Home Assistant's own source, and 2026.8 uses the unparenthesised
+      # "except A, B:" form that only exists from 3.14 on. Asking mypy to read
+      # it as 3.13 is a syntax error before any checking starts.
       - name: Run mypy
         run: |
           mypy --strict --namespace-packages --explicit-package-bases \
+            --python-version 3.14 \
             --module custom_components.dynamic_energy_contract_calculator
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,13 @@ jobs:
       # The pre-commit hook type-checks in its own isolated environment against
       # homeassistant-stubs; this step runs against the Home Assistant that
       # requirements.txt actually resolves, which is what the tests import.
+      # Addressed as a module, with the same package flags the hook uses:
+      # passing the directory makes mypy see __init__.py under two module
+      # names and stop before checking anything.
       - name: Run mypy
-        run: mypy --strict custom_components/dynamic_energy_contract_calculator
+        run: |
+          mypy --strict --namespace-packages --explicit-package-bases \
+            --module custom_components.dynamic_energy_contract_calculator
 
   test:
     # Home Assistant's supported Python floor decides which Home Assistant

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,21 @@ name: CI
 
 on:
   push:
-    branches: ["dev", "feature/**", "fix/**", "hotfix/**"]
+    # main is included because bump-version.yml pushes the version commit and
+    # its tag straight to main, and release.yml builds the shipped ZIP from
+    # that tag. Without main here, the one commit that reaches users is the
+    # one commit no job ever tests.
+    branches: ["main", "dev", "feature/**", "fix/**", "hotfix/**"]
     tags-ignore: ["**"]
   pull_request:
     branches: [dev, main]
+  # pytest-homeassistant-custom-component is deliberately unpinned, so the
+  # suite tracks whatever Home Assistant is current. That means a Home
+  # Assistant release can break this integration without anyone touching the
+  # repository — the weekly run surfaces it instead of the next contributor.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -23,27 +34,60 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
+          cache: pip
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install dependencies
+        run: pip install pre-commit mypy -r requirements.txt
+
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit
         run: pre-commit run --all-files
 
+      # The pre-commit hook type-checks in its own isolated environment against
+      # homeassistant-stubs; this step runs against the Home Assistant that
+      # requirements.txt actually resolves, which is what the tests import.
+      - name: Run mypy
+        run: mypy --strict custom_components/dynamic_energy_contract_calculator
+
   test:
-    name: Test (Python 3.13)
+    # Home Assistant's supported Python floor decides which Home Assistant
+    # version pip can install. On 3.13 the newest resolvable release is
+    # 2026.2.3, because Home Assistant 2026.3 onwards requires Python 3.14.2.
+    # Testing only on 3.13 therefore validates against a Home Assistant that
+    # is months behind what users run, without saying so anywhere.
+    #
+    # 3.14 is the version that matters; 3.13 is kept so the older supported
+    # Home Assistant line does not silently break.
+    name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14", "3.13"]
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install dependencies
         run: pip install -r requirements.txt
+
+      # Which Home Assistant a green run actually proves compatibility with is
+      # otherwise invisible, since the dependency is unpinned by design.
+      - name: Report the resolved Home Assistant version
+        run: |
+          HA_VERSION=$(pip show homeassistant | awk '/^Version:/ {print $2}')
+          echo "Python ${{ matrix.python-version }} resolved Home Assistant $HA_VERSION"
+          echo "- Python \`${{ matrix.python-version }}\` → Home Assistant \`$HA_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run pytest
         run: pytest --cov=custom_components --cov-report=xml -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Create Release
 
+# Triggered by publishing the release, not by the tag push, so the workflow
+# can read the release you created and honour the "Previous tag" you picked
+# there. GitHub does not expose that choice as a field — the only durable
+# trace is the compare link in the notes it generates — so it is recovered
+# from the release body below.
 on:
-  push:
-    tags: ["v*.*.*"]
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -13,12 +18,53 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Get version from tag
         id: version
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          TAG="${{ github.event.release.tag_name }}"
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Resolve previous tag from the release notes
+        id: prev
+        env:
+          # Quoted via env rather than inlined, so a body containing quotes or
+          # backticks cannot break out of the script.
+          BODY: ${{ github.event.release.body }}
+        run: |
+          # "Generate release notes" appends a line of the form:
+          #   **Full Changelog**: https://github.com/OWNER/REPO/compare/v1.9.0...v2.0.0
+          # The tag before "..." is exactly the previous release that was
+          # selected in the UI. Take the last occurrence, in case the body
+          # quotes other compare links above it.
+          FROM_TAG=$(printf '%s\n' "$BODY" \
+            | sed -nE 's#.*/compare/([^/[:space:]]+)\.\.\.[^[:space:])]+.*#\1#p' \
+            | tail -1)
+          if [ -n "$FROM_TAG" ]; then
+            echo "Using previous tag from the release notes: $FROM_TAG"
+          else
+            echo "No compare link in the release body; letting the changelog"
+            echo "builder fall back to the most recent tag."
+          fi
+          echo "from_tag=$FROM_TAG" >> $GITHUB_OUTPUT
+
+      # bump-my-version already updates manifest.json (see .bumpversion.toml)
+      # in the very commit this tag points at, so there is nothing to rewrite
+      # here. What this does catch is a tag created by hand, which would ship a
+      # ZIP whose manifest disagrees with the version HACS offers.
+      - name: Verify the tag matches the manifest version
+        run: |
+          MANIFEST_VERSION=$(python3 -c \
+            "import json; print(json.load(open('custom_components/dynamic_energy_contract_calculator/manifest.json'))['version'])")
+          if [ "$MANIFEST_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Tag ${{ github.event.release.tag_name }} does not match" \
+                 "manifest.json version $MANIFEST_VERSION. The tag was probably" \
+                 "created by hand instead of through the Bump Version workflow."
+            exit 1
+          fi
+          echo "manifest.json version $MANIFEST_VERSION matches the tag."
 
       - name: Create release ZIP
         run: |
@@ -29,6 +75,9 @@ jobs:
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v6
         with:
+          # Empty fromTag = keep the action's own "most recent tag" detection.
+          fromTag: ${{ steps.prev.outputs.from_tag }}
+          toTag: ${{ github.event.release.tag_name }}
           commitMode: true
           configuration: |
             {
@@ -56,6 +105,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          # The release already exists (this runs on publish); naming the tag
+          # makes it update that one instead of guessing from the ref.
+          tag_name: ${{ github.event.release.tag_name }}
           files: dynamic_energy_contract_calculator.zip
           body: |
             ${{ steps.changelog.outputs.changelog }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,50 @@
 repos:
+  # v3.15.2 crashes on Python 3.14: it calls tokenize.cookie_re, which CPython
+  # 3.14 turned into a bytes pattern, giving "cannot use a bytes pattern on a
+  # string-like object". v3.21.2 carries its own string-based _cookie_re.
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-        args:
-          - --safe
-          - --quiet
-        files: ^((homeassistant|script|tests)/.+)?[^/]+\.py$
+
+  # black was dropped here: its pin (24.4.2) predates Python 3.13, let alone
+  # 3.14, and ruff-format below already formats the same files in the same
+  # style — and unlike black's file filter, it covers custom_components/ too.
+
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.1
     hooks:
       - id: codespell
         args:
           - --ignore-words-list=hass,alot,datas,dof,dur,farenheit,hist,iff,ines,ist,lightsensor,mut,nd,pres,referer,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,bilt
-          - --skip="./.*,*.csv,*.json"
+          - --skip="./.*,*.csv,*.json,*.ambr"
           - --quiet-level=2
         exclude_types: [csv, json]
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.4.8
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         always_run: true
         pass_filenames: false
+        # Pin the interpreter: without this, pre-commit builds the hook env
+        # with whatever Python it happens to run under, and pip then silently
+        # resolves homeassistant-stubs down to the newest release that old
+        # interpreter allows — type-checking against stubs that predate the
+        # APIs this integration uses, and reporting green either way.
+        language_version: python3.14
+        additional_dependencies:
+          # Floor, so an environment that cannot satisfy it fails loudly
+          # instead of quietly type-checking against two-year-old stubs.
+          - homeassistant-stubs>=2025.1.0
         args:
           - --strict
           - --ignore-missing-imports
@@ -51,4 +63,3 @@ repos:
           - --show-error-context
           - --module
           - custom_components.dynamic_energy_contract_calculator
-        files: ^custom_components/dynamic_energy_contract_calculator/.*\\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,9 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=hass,alot,datas,dof,dur,farenheit,hist,iff,ines,ist,lightsensor,mut,nd,pres,referer,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,bilt
+          # thirdparty: an isort section name in setup.cfg, which v2.4.1
+          # started reporting as "third party".
+          - --ignore-words-list=hass,alot,datas,dof,dur,farenheit,hist,iff,ines,ist,lightsensor,mut,nd,pres,referer,ser,serie,te,technik,thirdparty,ue,uint,visability,wan,wanna,withing,bilt
           - --skip="./.*,*.csv,*.json,*.ambr"
           - --quiet-level=2
         exclude_types: [csv, json]
@@ -25,7 +27,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.4
     hooks:
-      - id: ruff
+      # ruff-check, not ruff: the bare id is a legacy alias in this revision
+      # and warns on every run.
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 

--- a/tests/test_sensor_additional.py
+++ b/tests/test_sensor_additional.py
@@ -594,9 +594,10 @@ async def test_current_price_schedule_sunrise_sunset_update(hass: HomeAssistant)
     tomorrow_sunrise = now + timedelta(days=1, hours=1)
     tomorrow_sunset = now + timedelta(days=1, hours=5)
     calls = {}
-    sensor.async_write_ha_state = lambda *args, **kwargs: calls.setdefault(
-        "write", 0
-    ) or calls.__setitem__("write", calls.get("write", 0) + 1)
+    sensor.async_write_ha_state = lambda *args, **kwargs: (
+        calls.setdefault("write", 0)
+        or calls.__setitem__("write", calls.get("write", 0) + 1)
+    )
 
     def fake_track_point_in_time(hass_arg, callback, when):
         calls["when"] = when
@@ -661,9 +662,10 @@ async def test_total_cost_sensor_added_with_platform_updates(hass: HomeAssistant
     )
     sensor.platform = object()
     calls = {}
-    sensor.async_write_ha_state = lambda *a, **k: calls.setdefault(
-        "write", 0
-    ) or calls.__setitem__("write", calls.get("write", 0) + 1)
+    sensor.async_write_ha_state = lambda *a, **k: (
+        calls.setdefault("write", 0)
+        or calls.__setitem__("write", calls.get("write", 0) + 1)
+    )
 
     async def fake_update():
         calls["updated"] = True
@@ -723,9 +725,10 @@ async def test_total_energy_cost_added_with_platform_updates(hass: HomeAssistant
     )
     sensor.platform = object()
     calls = {}
-    sensor.async_write_ha_state = lambda *a, **k: calls.setdefault(
-        "writes", 0
-    ) or calls.__setitem__("writes", calls.get("writes", 0) + 1)
+    sensor.async_write_ha_state = lambda *a, **k: (
+        calls.setdefault("writes", 0)
+        or calls.__setitem__("writes", calls.get("writes", 0) + 1)
+    )
 
     async def fake_update():
         calls["updated"] = True

--- a/tests/test_solar_bonus.py
+++ b/tests/test_solar_bonus.py
@@ -600,6 +600,6 @@ async def test_is_daylight_hour_fallback_boundary_hours(hass: HomeAssistant):
                 "custom_components.dynamic_energy_contract_calculator.solar_bonus.dt_util.now",
                 return_value=datetime(2025, 7, 1, hour, 0, 0, tzinfo=timezone.utc),
             ):
-                assert (
-                    tracker.is_daylight() is expected
-                ), f"hour={hour} expected {expected}"
+                assert tracker.is_daylight() is expected, (
+                    f"hour={hour} expected {expected}"
+                )


### PR DESCRIPTION
## Description

Ports the CI/CD changes made in `bvweerd/battery_controller`, minus the parts that have no counterpart here — there is no docs site and no JS in this repository, so the Pages workflow and the Node job are not carried over. The other workflows (`bump-version`, `label-issues`, `label-prs`, `stale`, `sync-labels`) are already byte-identical between the two repositories.

**CI now runs on `main`.** The push trigger covered `dev` and the feature branch patterns but not `main`. `bump-version.yml` pushes the version commit and its tag straight to `main`, and `release.yml` builds the shipped ZIP from that tag — so the one commit that reaches users was the one commit no job ever ran against.

**The test job runs a matrix over Python 3.14 and 3.13.** `pytest-homeassistant-custom-component` is unpinned by design, which means the interpreter decides which Home Assistant pip can resolve: on 3.13 the newest installable release is 2026.2.3, because Home Assistant 2026.3 onwards requires Python 3.14.2. The suite has therefore been validating against a Home Assistant months behind what users run, with nothing saying so. 3.13 is kept so the older supported line does not break unnoticed, `fail-fast` is off so one leg cannot hide the other, and the resolved Home Assistant version is printed into the job summary so a green run states what it is green against.

**A weekly schedule and `workflow_dispatch` are added** for the same reason: a Core release can break this integration without anyone touching the repository.

**The lint job** moves to 3.14, caches pip and the pre-commit hook environments, and runs mypy against the Home Assistant that `requirements.txt` actually resolves rather than only against stubs.

**pre-commit follows from that:**

- `pyupgrade` v3.15.2 crashes on Python 3.14 — it calls `tokenize.cookie_re`, which CPython 3.14 turned into a bytes pattern. v3.21.2 carries its own string-based copy.
- The mypy hook pinned no interpreter and pulled no Home Assistant stubs, so `--strict` was type-checking every HA symbol as `Any`. It now pins `python3.14` and floors `homeassistant-stubs` at 2025.1.0.
- `black` is dropped. Its pin (24.4.2) predates Python 3.13, and `ruff-format` already covers the same files in the same style — `.claude/rules/code-style.md` has documented `ruff format` as black's replacement all along, so this only makes the config match the rule.
- Remaining hook revisions brought up to date.

**`release.yml` is triggered by publishing the release** instead of by the tag push, so it can read the release body and recover the "Previous tag" chosen in the UI from the compare link in the generated notes — that selection had no effect on the rebuilt changelog before. A check is also added that fails the release when the tag and `manifest.json` disagree, catching a tag created by hand instead of through the Bump Version workflow.

**Separately: `.bumpversion.toml` was broken.** It still declared `current_version = "1.3.6"` while `manifest.json` and `setup.cfg` are both at 2.0.0. `bump-my-version` searches for the literal old version string, so the Bump Version workflow would have failed on its next run. Corrected to 2.0.0.

### Behaviour change to be aware of

Pushing a bare tag no longer produces a release on its own. Releases are created through the GitHub UI or API — publish the release for the tag that `bump-version.yml` pushed, and this workflow then attaches the ZIP and rewrites the notes.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [x] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [ ] Tests added or updated where applicable — no test changes; this is CI configuration only
- [ ] Documentation updated if needed — `.claude/rules/code-style.md` already described `ruff format` as black's replacement, so no doc change was required
- [ ] CI is green — pending on this PR
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)