### PR TITLE
fix: swap the icons on the two current price sensors

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -1550,7 +1550,11 @@ async def async_setup_entry(
                 price_sensor=price_sensor,
                 source_type=SOURCE_TYPE_CONSUMPTION,
                 price_settings=price_settings,
-                icon="mdi:transmission-tower-import",
+                # MDI names these from the tower's point of view, which reads
+                # backwards here: -export is tagged power-from-grid and
+                # -import power-to-grid / return-to-grid. SENSOR_MODES_ELECTRICITY
+                # above already follows that.
+                icon="mdi:transmission-tower-export",
                 device=device_info,
             )
         )
@@ -1562,7 +1566,7 @@ async def async_setup_entry(
                 price_sensor=price_sensor,
                 source_type=SOURCE_TYPE_PRODUCTION,
                 price_settings=price_settings,
-                icon="mdi:transmission-tower-export",
+                icon="mdi:transmission-tower-import",
                 device=device_info,
             )
         )


### PR DESCRIPTION
## Description

The icons on `Current Consumption Price` and `Current Production Price` were the wrong way round.

MDI names these two icons from the transmission tower's point of view, which reads backwards for a household sensor. The official tags are:

| Icon | MDI tags |
|---|---|
| `transmission-tower-export` | power-from-grid, energy-from-grid, electricity-from-grid |
| `transmission-tower-import` | power-to-grid, energy-to-grid, **return-to-grid** |

So consumption belongs to `-export` and production (teruglevering) to `-import`.

`SENSOR_MODES_ELECTRICITY` already follows that for `kwh_during_cost_total` and `kwh_during_profit_total`, so before this change the integration used both conventions at once.

Reported by @Kars-de-Jong in #159. Unrelated to the feature request in that issue, so it is split out here rather than shipped with the NextEnergy work.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [ ] Tests added or updated where applicable — no test covers icon choice, and none is added for a two-line constant swap
- [x] Documentation updated if needed — n/a, a code comment records why the names read backwards
- [x] CI is green — 207 tests pass, pre-commit and `mypy --strict` clean locally
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

n/a — the change is a two-line icon swap plus a comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_014yMhUYhzVhrDUjTV11LNDN)_