### PR TITLE
fix: include the solar bonus in the current price sensor state

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -578,6 +578,27 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                 return None
         return round(price, 8)
 
+    def _price_with_solar_bonus(self, base_price: float) -> float | None:
+        """Return the price for right now, including any solar bonus due.
+
+        _calculate_price carries no bonus term. The paths that set the state
+        straight from it would otherwise report a price that the forecast in
+        net_prices_today contradicts, because _convert_raw_prices does add the
+        bonus. Both must apply the same rule.
+        """
+        price = self._calculate_price(base_price)
+        if price is None:
+            return None
+        if self.source_type != SOURCE_TYPE_PRODUCTION or not self.price_settings.get(
+            "solar_bonus_enabled", False
+        ):
+            return price
+
+        if price > 0 and self._is_daylight_at(dt_util.now()):
+            percentage = self.price_settings.get("solar_bonus_percentage", 10.0)
+            price = round(price + price * (percentage / 100.0), 8)
+        return price
+
     def _normalize_price_entries(self, entries: Any) -> list[dict[str, Any]] | None:
         """Return list of entries with numeric value field."""
         if not isinstance(entries, list):
@@ -1117,7 +1138,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             self._schedule_next_price_change()
         else:
             # Without averaging: calculate price directly from current base price
-            price = self._calculate_price(total_price)
+            price = self._price_with_solar_bonus(total_price)
             if price is not None:
                 self._attr_native_value = price
 
@@ -1181,7 +1202,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                         total_price += float(state.state)
                     except ValueError:
                         pass
-            price = self._calculate_price(total_price)
+            price = self._price_with_solar_bonus(total_price)
             if price is not None:
                 self._attr_native_value = price
 
@@ -1285,7 +1306,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                         except ValueError:
                             pass
 
-                price = self._calculate_price(total_price)
+                price = self._price_with_solar_bonus(total_price)
                 if price is not None:
                     self._attr_native_value = price
 

--- a/tests/test_sensor_additional.py
+++ b/tests/test_sensor_additional.py
@@ -626,7 +626,9 @@ async def test_current_price_schedule_sunrise_sunset_update(hass: HomeAssistant)
 
         await calls["callback"](sunrise)
 
-    assert sensor.native_value == pytest.approx(1.5)
+    # Sunrise is what this update exists for, so the state it writes has to
+    # carry the bonus — 1.5 + 10% — like the forecast attributes do.
+    assert sensor.native_value == pytest.approx(1.65)
 
 
 async def test_solar_bonus_status_sensor_update(hass: HomeAssistant):
@@ -1152,10 +1154,19 @@ async def test_current_price_async_update_without_averaging_schedules_sunrise(
         "scheduled", True
     )
 
-    await sensor.async_update()
+    # Pin daylight rather than depend on the wall clock at test time
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(1.1)
+    assert called["scheduled"] is True
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: False)
+        await sensor.async_update()
 
     assert sensor.native_value == pytest.approx(1.0)
-    assert called["scheduled"] is True
 
 
 async def test_sensor_async_setup_entry_creates_new_trackers(hass: HomeAssistant):
@@ -1449,3 +1460,122 @@ async def test_is_contract_anniversary_helper():
     assert _is_contract_anniversary("2020-02-29", date(2025, 3, 1)) is False
     # Feb 29 on actual leap year matches exactly
     assert _is_contract_anniversary("2020-02-29", date(2024, 2, 29)) is True
+
+
+async def test_current_price_state_includes_solar_bonus_without_averaging(
+    hass: HomeAssistant,
+):
+    """Without averaging the state is calculated directly, and must carry the bonus.
+
+    net_prices_today already includes it, so a state without it contradicts
+    the sensor's own attributes.
+    """
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Direct Price",
+        "direct-price",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": False,
+            "per_unit_supplier_electricity_production_markup": 0.02,
+            "solar_bonus_enabled": True,
+            "solar_bonus_percentage": 10.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "direct-price")}),
+    )
+    hass.states.async_set("sensor.price", 0.10)
+    sensor._schedule_sunrise_sunset_updates = lambda: None
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(0.132)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: False)
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(0.12)
+
+
+async def test_current_price_fallback_includes_solar_bonus(hass: HomeAssistant):
+    """The averaged path falls back to a direct calculation, which needs the bonus too.
+
+    A price sensor that publishes no raw_today leaves _update_current_price
+    with nothing to match, so averaging being enabled is no guarantee the
+    state comes from the converted forecast.
+    """
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Fallback Price",
+        "fallback-price",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": True,
+            "per_unit_supplier_electricity_production_markup": 0.02,
+            "solar_bonus_enabled": True,
+            "solar_bonus_percentage": 10.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "fallback-price")}),
+    )
+    hass.states.async_set("sensor.price", 0.10)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(0.132)
+
+
+async def test_scheduled_sun_event_writes_bonus_price(hass: HomeAssistant):
+    """The sunrise/sunset update exists to change the price, so it must apply the bonus."""
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Sun Event",
+        "sun-event-bonus",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": False,
+            "per_unit_supplier_electricity_production_markup": 0.02,
+            "solar_bonus_enabled": True,
+            "solar_bonus_percentage": 10.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "sun-event-bonus")}),
+    )
+    hass.states.async_set("sensor.price", 0.10)
+    now = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+    sunrise = now + timedelta(hours=1)
+    calls = {}
+    sensor.async_write_ha_state = lambda *a, **k: calls.setdefault("write", True)
+
+    def fake_track_point_in_time(hass_arg, callback, when):
+        calls["callback"] = callback
+        return lambda: None
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor_module.dt_util, "now", lambda: now)
+        mp.setattr(
+            sensor,
+            "_get_sunrise_sunset_times",
+            lambda date_obj: (sunrise, now + timedelta(hours=5)),
+        )
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
+        mp.setattr(sensor_module, "async_track_point_in_time", fake_track_point_in_time)
+        sensor._schedule_sunrise_sunset_updates()
+        await calls["callback"](sunrise)
+
+    assert sensor.native_value == pytest.approx(0.132)
+    assert calls["write"] is True


### PR DESCRIPTION
## Description

The state of `Current Production Price` excluded the solar bonus while `net_prices_today` in its own attributes included it.

`_calculate_price` carries no bonus term, and three paths set the state straight from it:

| Path | When it runs |
|---|---|
| `async_update`, else-branch | `average_prices_to_hourly` is off |
| `_update_current_price` fallback | no forecast entry covers the current moment |
| scheduled sunrise/sunset update | whenever it fires |

Only the averaged path read its value from the converted forecast, so only that path ever showed a bonus. The scheduled update gave the gap away: it recomputed a price that could never change, because the function it called had no bonus in it.

All three now go through `_price_with_solar_bonus`, which applies the same rule `_convert_raw_prices` already applied to the forecast.

**Enabling averaging is not a workaround.** A price sensor that publishes no `raw_today`, or entries the matcher skips, leaves `_update_current_price` with nothing to match and falls through to the same direct calculation. Verified against this branch's parent: a Zonneplan-shaped setup reports `0.12` where `0.132` is due.

Reported by @Kars-de-Jong in #159 while testing V1.4.0b1. The defect predates that beta and is unrelated to the NextEnergy feature request, so it is split out here.

## Type of change

- [x] `fix:` Bug fix (patch version bump)
- [ ] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable — three new tests, one per path; two existing tests asserted the old values and are updated
- [x] Documentation updated if needed — n/a, behaviour now matches what the attributes already documented
- [x] CI is green — 210 tests pass, pre-commit and `mypy --strict` clean locally
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

One of the updated tests depended on the wall clock at test time and would have started flipping between daylight and night with this change; it now pins daylight explicitly.

---
_Generated by [Claude Code](https://claude.ai/code/session_014yMhUYhzVhrDUjTV11LNDN)_