### PR TITLE
feat: make the solar bonus configurable per supplier and add a NextEnergy preset

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/binary_sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/binary_sensor.py
@@ -17,6 +17,10 @@ from .const import (
     CONF_PRICE_SETTINGS,
     DOMAIN,
     DOMAIN_ABBREVIATION,
+    SOLAR_BONUS_BASE_MARKET_ONLY,
+    SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+    SOLAR_BONUS_LIMIT_CALENDAR_YEAR,
+    SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
     SOURCE_TYPE_PRODUCTION,
     SUBENTRY_TYPE_SOURCE,
 )
@@ -71,7 +75,12 @@ async def async_setup_entry(
         if solar_bonus_tracker is None:
             contract_start_date = price_settings.get("contract_start_date", "")
             solar_bonus_tracker = await SolarBonusTracker.async_create(
-                hass, entry.entry_id, contract_start_date
+                hass,
+                entry.entry_id,
+                contract_start_date,
+                price_settings.get(
+                    "solar_bonus_limit_period", SOLAR_BONUS_LIMIT_CALENDAR_YEAR
+                ),
             )
             solar_bonus_map[entry.entry_id] = solar_bonus_tracker
 
@@ -161,8 +170,14 @@ class SolarBonusActiveBinarySensor(BinarySensorEntity):
         # Check if solar bonus conditions are met
         is_active = False
 
-        # Check if daylight
-        if self._solar_bonus_tracker.is_daylight():
+        # Check if we are inside the supplier's bonus window
+        if self._solar_bonus_tracker.is_in_bonus_window(
+            self._price_settings.get(
+                "solar_bonus_window_mode", SOLAR_BONUS_WINDOW_SUNRISE_SUNSET
+            ),
+            self._price_settings.get("solar_bonus_start_hour", 6.0),
+            self._price_settings.get("solar_bonus_end_hour", 22.0),
+        ):
             # Check if under annual limit
             annual_limit = self._price_settings.get(
                 "solar_bonus_annual_kwh_limit", 7500.0
@@ -180,7 +195,18 @@ class SolarBonusActiveBinarySensor(BinarySensorEntity):
                             production_markup = self._price_settings.get(
                                 "per_unit_supplier_electricity_production_markup", 0.0
                             )
-                            total_price = base_price + production_markup
+                            # Mirror the tracker: a market-only bonus ignores
+                            # the production markup for this condition too.
+                            if (
+                                self._price_settings.get(
+                                    "solar_bonus_base",
+                                    SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+                                )
+                                == SOLAR_BONUS_BASE_MARKET_ONLY
+                            ):
+                                total_price = base_price
+                            else:
+                                total_price = base_price + production_markup
                             if total_price > 0:
                                 is_active = True
                         except (ValueError, TypeError):

--- a/custom_components/dynamic_energy_contract_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_contract_calculator/config_flow.py
@@ -22,6 +22,9 @@ from .const import (
     CONF_SOURCES,
     DEFAULT_PRICE_SETTINGS,
     DOMAIN,
+    SOLAR_BONUS_BASE_OPTIONS,
+    SOLAR_BONUS_LIMIT_PERIOD_OPTIONS,
+    SOLAR_BONUS_WINDOW_OPTIONS,
     SOURCE_TYPE_GAS,
     SOURCE_TYPES,
     SUBENTRY_TYPE_SOURCE,
@@ -57,8 +60,20 @@ ELECTRICITY_FIELDS = ELECTRICITY_CORE_FIELDS | {
     "solar_bonus_enabled",
     "solar_bonus_percentage",
     "solar_bonus_annual_kwh_limit",
+    "solar_bonus_base",
+    "solar_bonus_window_mode",
+    "solar_bonus_start_hour",
+    "solar_bonus_end_hour",
+    "solar_bonus_limit_period",
     "contract_start_date",
     "reset_on_contract_anniversary",
+}
+
+# Price settings rendered as a dropdown instead of a free-text field.
+SELECT_FIELD_OPTIONS = {
+    "solar_bonus_base": SOLAR_BONUS_BASE_OPTIONS,
+    "solar_bonus_window_mode": SOLAR_BONUS_WINDOW_OPTIONS,
+    "solar_bonus_limit_period": SOLAR_BONUS_LIMIT_PERIOD_OPTIONS,
 }
 
 GENERAL_FIELDS = {
@@ -162,7 +177,17 @@ def _build_price_settings_schema(
         if isinstance(default, bool):
             schema_fields[vol.Required(key, default=current)] = bool
         elif isinstance(default, str):
-            if key == "contract_start_date":
+            if key in SELECT_FIELD_OPTIONS:
+                schema_fields[vol.Required(key, default=current)] = selector(
+                    {
+                        "select": {
+                            "options": SELECT_FIELD_OPTIONS[key],
+                            "mode": "dropdown",
+                            "translation_key": key,
+                        }
+                    }
+                )
+            elif key == "contract_start_date":
                 if current and current != "":
                     schema_fields[vol.Optional(key, default=current)] = selector(
                         {"date": {}}

--- a/custom_components/dynamic_energy_contract_calculator/const.py
+++ b/custom_components/dynamic_energy_contract_calculator/const.py
@@ -170,8 +170,38 @@ PRESET_GREENCHOICE_GAS_2026 = {
     "reset_on_contract_anniversary": False,
 }
 
+# NextEnergy 2026: Zonnebonus contract terms.
+#
+# Deliberately carries no supply tariffs. NextEnergy does not publish its
+# inkoopvergoeding, vaste leveringskosten or netbeheerkosten: they depend on
+# when a customer signed up and are only visible in the app. Comparison sites
+# quote conflicting figures, so those fields are left out entirely — keys
+# absent from a preset are not written, which keeps whatever the user
+# configured from their own tarievenblad.
+#
+# Everything below is published by NextEnergy itself.
+PRESET_NEXTENERGY_2026 = {
+    # NextSolar is sold on charging no per-kWh feed-in cost.
+    "per_unit_supplier_electricity_production_markup": 0.0,
+    # NextEnergy settles on quarter-hour prices.
+    "average_prices_to_hourly": False,
+    # Zonnebonus: 50% over the bare exchange price, for electricity fed back
+    # between 06:00 and 22:00, up to 6000 kWh per contract year, and never
+    # negative when exchange prices are.
+    "solar_bonus_enabled": True,
+    "solar_bonus_percentage": 50.0,
+    "solar_bonus_annual_kwh_limit": 6000.0,
+    "solar_bonus_base": SOLAR_BONUS_BASE_MARKET_ONLY,
+    "solar_bonus_window_mode": SOLAR_BONUS_WINDOW_FIXED_HOURS,
+    "solar_bonus_start_hour": 6.0,
+    "solar_bonus_end_hour": 22.0,
+    "solar_bonus_limit_period": SOLAR_BONUS_LIMIT_CONTRACT_YEAR,
+    "reset_on_contract_anniversary": True,
+}
+
 SUPPLIER_PRESETS = {
     "zonneplan_2026": PRESET_ZONNEPLAN_2026,
+    "nextenergy_2026": PRESET_NEXTENERGY_2026,
     "greenchoice_gas_2026": PRESET_GREENCHOICE_GAS_2026,
 }
 

--- a/custom_components/dynamic_energy_contract_calculator/const.py
+++ b/custom_components/dynamic_energy_contract_calculator/const.py
@@ -29,6 +29,35 @@ SOURCE_TYPES = [
 
 CONF_CONFIGS = "configurations"
 
+# Solar bonus: which amount the bonus percentage is applied to.
+# Suppliers differ here. Zonneplan pays a percentage over the full feed-in
+# compensation (market price + purchase allowance), NextEnergy pays a
+# percentage over the bare exchange price only.
+SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP = "market_plus_markup"
+SOLAR_BONUS_BASE_MARKET_ONLY = "market_only"
+SOLAR_BONUS_BASE_OPTIONS = [
+    SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+    SOLAR_BONUS_BASE_MARKET_ONLY,
+]
+
+# Solar bonus: which part of the day qualifies for the bonus.
+# Zonneplan uses sunrise to sunset, NextEnergy a fixed 06:00-22:00 window.
+SOLAR_BONUS_WINDOW_SUNRISE_SUNSET = "sunrise_sunset"
+SOLAR_BONUS_WINDOW_FIXED_HOURS = "fixed_hours"
+SOLAR_BONUS_WINDOW_OPTIONS = [
+    SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
+    SOLAR_BONUS_WINDOW_FIXED_HOURS,
+]
+
+# Solar bonus: the period over which the annual kWh limit is counted.
+# Zonneplan resets per calendar year, NextEnergy per contract year.
+SOLAR_BONUS_LIMIT_CALENDAR_YEAR = "calendar_year"
+SOLAR_BONUS_LIMIT_CONTRACT_YEAR = "contract_year"
+SOLAR_BONUS_LIMIT_PERIOD_OPTIONS = [
+    SOLAR_BONUS_LIMIT_CALENDAR_YEAR,
+    SOLAR_BONUS_LIMIT_CONTRACT_YEAR,
+]
+
 PRICE_SETTINGS_KEYS = [
     "per_unit_supplier_electricity_markup",
     "per_unit_supplier_electricity_production_markup",
@@ -47,6 +76,11 @@ PRICE_SETTINGS_KEYS = [
     "solar_bonus_enabled",
     "solar_bonus_percentage",
     "solar_bonus_annual_kwh_limit",
+    "solar_bonus_base",
+    "solar_bonus_window_mode",
+    "solar_bonus_start_hour",
+    "solar_bonus_end_hour",
+    "solar_bonus_limit_period",
     "contract_start_date",
     "reset_on_contract_anniversary",
 ]
@@ -69,6 +103,11 @@ DEFAULT_PRICE_SETTINGS = {
     "solar_bonus_enabled": False,
     "solar_bonus_percentage": 10.0,
     "solar_bonus_annual_kwh_limit": 7500.0,
+    "solar_bonus_base": SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+    "solar_bonus_window_mode": SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
+    "solar_bonus_start_hour": 6.0,
+    "solar_bonus_end_hour": 22.0,
+    "solar_bonus_limit_period": SOLAR_BONUS_LIMIT_CALENDAR_YEAR,
     "contract_start_date": "",
     "reset_on_contract_anniversary": False,
 }
@@ -95,6 +134,13 @@ PRESET_ZONNEPLAN_2026 = {
     "solar_bonus_enabled": True,
     "solar_bonus_percentage": 10.0,
     "solar_bonus_annual_kwh_limit": 7500.0,
+    # 10% over market price + €0.02 purchase allowance, sunrise to sunset,
+    # 7500 kWh per calendar year.
+    "solar_bonus_base": SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+    "solar_bonus_window_mode": SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
+    "solar_bonus_start_hour": 6.0,
+    "solar_bonus_end_hour": 22.0,
+    "solar_bonus_limit_period": SOLAR_BONUS_LIMIT_CALENDAR_YEAR,
     "contract_start_date": "",
     "reset_on_contract_anniversary": True,
 }

--- a/custom_components/dynamic_energy_contract_calculator/entity.py
+++ b/custom_components/dynamic_energy_contract_calculator/entity.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+    SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
     SOURCE_TYPE_CONSUMPTION,
     SOURCE_TYPE_GAS,
     SOURCE_TYPE_PRODUCTION,
@@ -393,6 +395,17 @@ class DynamicEnergySensor(BaseUtilitySensor):
                         production_markup=markup_production,
                         bonus_percentage=bonus_percentage,
                         annual_limit_kwh=annual_limit,
+                        bonus_base=self.price_settings.get(
+                            "solar_bonus_base", SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP
+                        ),
+                        window_mode=self.price_settings.get(
+                            "solar_bonus_window_mode",
+                            SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
+                        ),
+                        start_hour=self.price_settings.get(
+                            "solar_bonus_start_hour", 6.0
+                        ),
+                        end_hour=self.price_settings.get("solar_bonus_end_hour", 22.0),
                     )
 
                     if solar_bonus_amount > 0:

--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Callable
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 from typing import Any
 
@@ -599,9 +599,19 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
         ):
             return price
 
-        if price > 0 and self._is_daylight_at(dt_util.now()):
+        if (
+            self.price_settings.get(
+                "solar_bonus_base", SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP
+            )
+            == SOLAR_BONUS_BASE_MARKET_ONLY
+        ):
+            bonus_base_amount = base_price
+        else:
+            bonus_base_amount = price
+
+        if bonus_base_amount > 0 and self._is_in_bonus_window_at(dt_util.now()):
             percentage = self.price_settings.get("solar_bonus_percentage", 10.0)
-            price = round(price + price * (percentage / 100.0), 8)
+            price = round(price + bonus_base_amount * (percentage / 100.0), 8)
         return price
 
     def _normalize_price_entries(self, entries: Any) -> list[dict[str, Any]] | None:
@@ -1199,9 +1209,9 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             if price is not None:
                 self._attr_native_value = price
 
-            # But still schedule sunrise/sunset updates if solar bonus is enabled
+            # But still schedule window updates if solar bonus is enabled
             if solar_bonus_enabled:
-                self._schedule_sunrise_sunset_updates()
+                self._schedule_bonus_window_updates()
 
     def _update_current_price(self) -> None:
         """Update the current price based on the current time and net_prices."""
@@ -1308,11 +1318,13 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                 self.hass, handle_next_change, next_change
             )
 
-    def _schedule_sunrise_sunset_updates(self) -> None:
-        """Schedule updates at sunrise and sunset for solar bonus (without averaging).
+    def _schedule_bonus_window_updates(self) -> None:
+        """Schedule updates at the edges of the solar bonus window.
 
-        This is used when average_prices_to_hourly is False but solar_bonus is enabled.
-        The sensor will update at sunrise/sunset to apply/remove the solar bonus.
+        Used when average_prices_to_hourly is False but solar_bonus is
+        enabled. Without per-entry prices to drive the schedule, the sensor
+        has to wake itself when the bonus starts or stops applying — at
+        sunrise and sunset, or at the fixed window hours.
         """
         # Cancel existing schedule
         if self._price_change_unsub:
@@ -1320,39 +1332,42 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             self._price_change_unsub = None
 
         now = dt_util.now()
-
-        # Get sunrise/sunset times for today and tomorrow
         today = now.date()
         tomorrow = today + timedelta(days=1)
 
-        sunrise_today, sunset_today = self._get_sunrise_sunset_times(today)
-        sunrise_tomorrow, sunset_tomorrow = self._get_sunrise_sunset_times(tomorrow)
+        candidates: list[datetime] = []
+        if (
+            self.price_settings.get(
+                "solar_bonus_window_mode", SOLAR_BONUS_WINDOW_SUNRISE_SUNSET
+            )
+            == SOLAR_BONUS_WINDOW_FIXED_HOURS
+        ):
+            # Boundaries are local clock hours; combining with the current
+            # tzinfo keeps them right across a DST change.
+            start_hour = int(self.price_settings.get("solar_bonus_start_hour", 6.0))
+            end_hour = int(self.price_settings.get("solar_bonus_end_hour", 22.0))
+            candidates = [
+                datetime.combine(day, time(hour=hour % 24), tzinfo=now.tzinfo)
+                for day in (today, tomorrow)
+                for hour in (start_hour, end_hour)
+            ]
+        else:
+            for day in (today, tomorrow):
+                sunrise, sunset = self._get_sunrise_sunset_times(day)
+                candidates.extend(event for event in (sunrise, sunset) if event)
 
-        # Find the next sunrise or sunset
-        next_event = None
-        candidates = []
-
-        if sunrise_today and sunrise_today > now:
-            candidates.append(sunrise_today)
-        if sunset_today and sunset_today > now:
-            candidates.append(sunset_today)
-        if sunrise_tomorrow and sunrise_tomorrow > now:
-            candidates.append(sunrise_tomorrow)
-        if sunset_tomorrow and sunset_tomorrow > now:
-            candidates.append(sunset_tomorrow)
-
-        if candidates:
-            next_event = min(candidates)
+        upcoming = [event for event in candidates if event > now]
+        next_event = min(upcoming) if upcoming else None
 
         if next_event:
             _LOGGER.debug(
-                "Scheduling sunrise/sunset update for %s at %s",
+                "Scheduling bonus window update for %s at %s",
                 self.entity_id,
                 next_event,
             )
 
-            async def handle_sun_event(now: datetime) -> None:
-                """Handle sunrise/sunset event - recalculate price and reschedule."""
+            async def handle_window_event(now: datetime) -> None:
+                """Handle a window edge - recalculate price and reschedule."""
                 # Recalculate the price
                 total_price = 0.0
                 for sensor in self.price_sensors:
@@ -1368,10 +1383,10 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                     self._attr_native_value = price
 
                 self.async_write_ha_state()
-                self._schedule_sunrise_sunset_updates()
+                self._schedule_bonus_window_updates()
 
             self._price_change_unsub = async_track_point_in_time(
-                self.hass, handle_sun_event, next_event
+                self.hass, handle_window_event, next_event
             )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -38,6 +38,11 @@ from .const import (
     CONF_SOURCES,
     DOMAIN,
     DOMAIN_ABBREVIATION,
+    SOLAR_BONUS_BASE_MARKET_ONLY,
+    SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+    SOLAR_BONUS_LIMIT_CALENDAR_YEAR,
+    SOLAR_BONUS_WINDOW_FIXED_HOURS,
+    SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
     SOURCE_TYPE_CONSUMPTION,
     SOURCE_TYPE_GAS,
     SOURCE_TYPE_PRODUCTION,
@@ -674,6 +679,39 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                 existing.append(entry_copy)
         return existing
 
+    def _is_in_bonus_window_at(self, timestamp: Any) -> bool:
+        """Check whether a forecast timestamp falls inside the bonus window.
+
+        Mirrors SolarBonusTracker.is_in_bonus_window for forecast entries,
+        which are evaluated at their own timestamp rather than at "now".
+        """
+        window_mode = self.price_settings.get(
+            "solar_bonus_window_mode", SOLAR_BONUS_WINDOW_SUNRISE_SUNSET
+        )
+        if window_mode != SOLAR_BONUS_WINDOW_FIXED_HOURS:
+            return self._is_daylight_at(timestamp)
+
+        try:
+            if isinstance(timestamp, str):
+                dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            else:
+                dt = timestamp
+        except Exception as e:
+            _LOGGER.warning("Failed to parse timestamp %s: %s", timestamp, e)
+            return False
+
+        # A fixed window is defined in local clock hours, so compare in the
+        # configured timezone rather than whatever the price feed supplied.
+        if dt.tzinfo is not None:
+            try:
+                dt = dt.astimezone(ZoneInfo(str(self.hass.config.time_zone)))
+            except Exception as e:  # pragma: no cover - invalid tz config
+                _LOGGER.debug("Could not convert %s to local time: %s", timestamp, e)
+
+        start_hour = int(self.price_settings.get("solar_bonus_start_hour", 6.0))
+        end_hour = int(self.price_settings.get("solar_bonus_end_hour", 22.0))
+        return bool(start_hour <= dt.hour < end_hour)
+
     def _is_daylight_at(self, timestamp: Any) -> bool:
         """Check if a given timestamp is during daylight hours.
 
@@ -968,10 +1006,22 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             and self.price_settings.get("solar_bonus_enabled", False)
         )
         solar_bonus_percentage = self.price_settings.get("solar_bonus_percentage", 10.0)
+        solar_bonus_base = self.price_settings.get(
+            "solar_bonus_base", SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP
+        )
+        solar_bonus_window_mode = self.price_settings.get(
+            "solar_bonus_window_mode", SOLAR_BONUS_WINDOW_SUNRISE_SUNSET
+        )
 
         # If solar bonus is enabled AND averaging to hourly is enabled,
-        # we need to split entries at sunrise/sunset
-        if solar_bonus_enabled and average_to_hourly and raw_prices:
+        # we need to split entries at sunrise/sunset. A fixed-hour window
+        # always falls on whole hours, so those entries need no splitting.
+        if (
+            solar_bonus_enabled
+            and average_to_hourly
+            and raw_prices
+            and solar_bonus_window_mode != SOLAR_BONUS_WINDOW_FIXED_HOURS
+        ):
             # Get all unique dates from entries
             dates_to_check = set()
             for entry in raw_prices:
@@ -1043,14 +1093,21 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
 
             # Apply solar bonus if conditions are met
             solar_bonus_applied = False
-            if solar_bonus_enabled and calculated is not None and calculated > 0:
-                # Check if this hour is during daylight
+            if solar_bonus_enabled and calculated is not None:
+                # The bonus is paid over the bare market price for some
+                # suppliers and over the full compensation for others, so the
+                # positive-price condition follows the same amount.
+                if solar_bonus_base == SOLAR_BONUS_BASE_MARKET_ONLY:
+                    bonus_base_amount = base
+                else:
+                    bonus_base_amount = calculated
+
                 timestamp = entry_conv.get("start") or entry_conv.get("time")
-                is_daylight = self._is_daylight_at(timestamp) if timestamp else False
-                if is_daylight:
-                    # Add solar bonus (10% extra)
-                    bonus = calculated * (solar_bonus_percentage / 100.0)
-                    calculated += bonus
+                in_window = (
+                    self._is_in_bonus_window_at(timestamp) if timestamp else False
+                )
+                if bonus_base_amount > 0 and in_window:
+                    calculated += bonus_base_amount * (solar_bonus_percentage / 100.0)
                     solar_bonus_applied = True
 
             entry_conv["value"] = calculated
@@ -1393,7 +1450,12 @@ async def async_setup_entry(
         contract_start_date = price_settings.get("contract_start_date", "")
         if sb_tracker is None:
             sb_tracker = await SolarBonusTracker.async_create(
-                hass, entry.entry_id, contract_start_date
+                hass,
+                entry.entry_id,
+                contract_start_date,
+                price_settings.get(
+                    "solar_bonus_limit_period", SOLAR_BONUS_LIMIT_CALENDAR_YEAR
+                ),
             )
             solar_bonus_map[entry.entry_id] = sb_tracker
         solar_bonus_tracker = sb_tracker

--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -578,6 +578,27 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                 return None
         return round(price, 8)
 
+    def _price_with_solar_bonus(self, base_price: float) -> float | None:
+        """Return the price for right now, including any solar bonus due.
+
+        _calculate_price carries no bonus term. The paths that set the state
+        straight from it would otherwise report a price that the forecast in
+        net_prices_today contradicts, because _convert_raw_prices does add the
+        bonus. Both must apply the same rule.
+        """
+        price = self._calculate_price(base_price)
+        if price is None:
+            return None
+        if self.source_type != SOURCE_TYPE_PRODUCTION or not self.price_settings.get(
+            "solar_bonus_enabled", False
+        ):
+            return price
+
+        if price > 0 and self._is_daylight_at(dt_util.now()):
+            percentage = self.price_settings.get("solar_bonus_percentage", 10.0)
+            price = round(price + price * (percentage / 100.0), 8)
+        return price
+
     def _normalize_price_entries(self, entries: Any) -> list[dict[str, Any]] | None:
         """Return list of entries with numeric value field."""
         if not isinstance(entries, list):
@@ -1117,7 +1138,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             self._schedule_next_price_change()
         else:
             # Without averaging: calculate price directly from current base price
-            price = self._calculate_price(total_price)
+            price = self._price_with_solar_bonus(total_price)
             if price is not None:
                 self._attr_native_value = price
 
@@ -1181,7 +1202,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                         total_price += float(state.state)
                     except ValueError:
                         pass
-            price = self._calculate_price(total_price)
+            price = self._price_with_solar_bonus(total_price)
             if price is not None:
                 self._attr_native_value = price
 
@@ -1285,7 +1306,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                         except ValueError:
                             pass
 
-                price = self._calculate_price(total_price)
+                price = self._price_with_solar_bonus(total_price)
                 if price is not None:
                     self._attr_native_value = price
 

--- a/custom_components/dynamic_energy_contract_calculator/solar_bonus.py
+++ b/custom_components/dynamic_energy_contract_calculator/solar_bonus.py
@@ -11,7 +11,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
-from .const import SOLAR_BONUS_STORAGE_KEY_PREFIX, SOLAR_BONUS_STORAGE_VERSION
+from .const import (
+    SOLAR_BONUS_BASE_MARKET_ONLY,
+    SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+    SOLAR_BONUS_LIMIT_CALENDAR_YEAR,
+    SOLAR_BONUS_LIMIT_CONTRACT_YEAR,
+    SOLAR_BONUS_STORAGE_KEY_PREFIX,
+    SOLAR_BONUS_STORAGE_VERSION,
+    SOLAR_BONUS_WINDOW_FIXED_HOURS,
+    SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     pass
@@ -29,27 +38,27 @@ class SolarBonusTracker:
         store: Store[dict[str, Any]],
         initial_state: dict[str, Any] | None,
         contract_start_date: str | None = None,
+        limit_period: str = SOLAR_BONUS_LIMIT_CALENDAR_YEAR,
     ) -> None:
         self._lock = asyncio.Lock()
         self._store = store
         self._entry_id = entry_id
         self._hass = hass
         self._contract_start_date = self._parse_date(contract_start_date)
+        self._limit_period = limit_period
 
-        # Track production eligible for bonus this contract year
+        # Track production eligible for bonus this limit period
         self._current_contract_year_start: date | None = None
         self._year_production_kwh: float = 0.0
         self._total_bonus_euro: float = 0.0
 
-        # Calculate current contract year start
-        if self._contract_start_date:
-            self._current_contract_year_start = self._get_current_contract_year_start()
+        self._current_contract_year_start = self._get_current_period_start()
 
         if initial_state:
             stored_year_start = self._parse_date(
                 initial_state.get("contract_year_start")
             )
-            # Reset if new contract year
+            # Reset if we rolled over into a new limit period
             if stored_year_start == self._current_contract_year_start:
                 self._year_production_kwh = float(
                     initial_state.get("year_production_kwh", 0.0)
@@ -66,6 +75,21 @@ class SolarBonusTracker:
             return datetime.fromisoformat(date_str).date()
         except (ValueError, AttributeError):
             return None
+
+    def _get_current_period_start(self) -> date | None:
+        """Return the start date of the current annual-limit period.
+
+        Contract-year periods run from the contract anniversary; every other
+        configuration counts per calendar year. Falling back to the calendar
+        year matters: without it a tracker with no contract start date would
+        never reset and would exhaust its annual limit permanently.
+        """
+        if (
+            self._limit_period == SOLAR_BONUS_LIMIT_CONTRACT_YEAR
+            and self._contract_start_date
+        ):
+            return self._get_current_contract_year_start()
+        return dt_util.now().date().replace(month=1, day=1)
 
     def _get_current_contract_year_start(self) -> date | None:
         """Get the start date of the current contract year."""
@@ -95,7 +119,11 @@ class SolarBonusTracker:
 
     @classmethod
     async def async_create(
-        cls, hass: HomeAssistant, entry_id: str, contract_start_date: str | None = None
+        cls,
+        hass: HomeAssistant,
+        entry_id: str,
+        contract_start_date: str | None = None,
+        limit_period: str = SOLAR_BONUS_LIMIT_CALENDAR_YEAR,
     ) -> SolarBonusTracker:
         """Create a tracker and restore persisted state."""
         storage_key = f"{SOLAR_BONUS_STORAGE_KEY_PREFIX}_{entry_id}"
@@ -106,7 +134,7 @@ class SolarBonusTracker:
             private=True,
         )
         initial = await store.async_load() or {}
-        return cls(hass, entry_id, store, initial, contract_start_date)
+        return cls(hass, entry_id, store, initial, contract_start_date, limit_period)
 
     @property
     def year_production_kwh(self) -> float:
@@ -140,6 +168,22 @@ class SolarBonusTracker:
         now = dt_util.now()
         return bool(6 <= now.hour < 20)
 
+    def is_in_bonus_window(
+        self,
+        window_mode: str = SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
+        start_hour: float = 6.0,
+        end_hour: float = 22.0,
+    ) -> bool:
+        """Check whether the current time falls inside the bonus window.
+
+        Suppliers define this window differently: Zonneplan pays the bonus
+        from sunrise to sunset, NextEnergy between fixed clock hours.
+        """
+        if window_mode == SOLAR_BONUS_WINDOW_FIXED_HOURS:
+            hour = dt_util.now().hour
+            return bool(int(start_hour) <= hour < int(end_hour))
+        return self.is_daylight()
+
     async def async_calculate_bonus(
         self,
         delta_kwh: float,
@@ -147,6 +191,10 @@ class SolarBonusTracker:
         production_markup: float,
         bonus_percentage: float,
         annual_limit_kwh: float,
+        bonus_base: str = SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+        window_mode: str = SOLAR_BONUS_WINDOW_SUNRISE_SUNSET,
+        start_hour: float = 6.0,
+        end_hour: float = 22.0,
     ) -> tuple[float, float]:
         """
         Calculate solar bonus for production delta.
@@ -157,29 +205,39 @@ class SolarBonusTracker:
             production_markup: Fixed production compensation per kWh
             bonus_percentage: Bonus percentage (e.g., 10.0 for 10%)
             annual_limit_kwh: Annual kWh limit for bonus (e.g., 7500)
+            bonus_base: Whether the percentage applies to the market price
+                only, or to the market price plus the production markup
+            window_mode: Sunrise-to-sunset or a fixed clock-hour window
+            start_hour: First hour of a fixed window (inclusive)
+            end_hour: Hour the fixed window ends (exclusive)
 
         Returns:
             Tuple of (bonus amount in euro, eligible kWh for this delta)
         """
         async with self._lock:
-            # Check if new contract year - reset if needed
-            if self._contract_start_date:
-                current_contract_year_start = self._get_current_contract_year_start()
-                if current_contract_year_start != self._current_contract_year_start:
-                    self._current_contract_year_start = current_contract_year_start
-                    self._year_production_kwh = 0.0
-                    self._total_bonus_euro = 0.0
+            # Reset the counter when we roll into a new limit period
+            current_period_start = self._get_current_period_start()
+            if current_period_start != self._current_contract_year_start:
+                self._current_contract_year_start = current_period_start
+                self._year_production_kwh = 0.0
+                self._total_bonus_euro = 0.0
 
             # Check conditions for bonus eligibility
             if delta_kwh <= 0:
                 return 0.0, 0.0
 
-            # Must be during daylight hours
-            if not self.is_daylight():
+            # Must be inside the supplier's bonus window
+            if not self.is_in_bonus_window(window_mode, start_hour, end_hour):
                 return 0.0, 0.0
 
-            # Base compensation must be positive
-            base_compensation = base_price + production_markup
+            # The amount the bonus percentage applies to. Suppliers that pay a
+            # percentage over the bare market price ignore the production
+            # markup entirely — including for the positive-price condition, so
+            # feed-in charges cannot suppress an otherwise valid bonus.
+            if bonus_base == SOLAR_BONUS_BASE_MARKET_ONLY:
+                base_compensation = base_price
+            else:
+                base_compensation = base_price + production_markup
             if base_compensation <= 0:
                 return 0.0, 0.0
 
@@ -207,10 +265,7 @@ class SolarBonusTracker:
         async with self._lock:
             self._year_production_kwh = 0.0
             self._total_bonus_euro = 0.0
-            if self._contract_start_date:
-                self._current_contract_year_start = (
-                    self._get_current_contract_year_start()
-                )
+            self._current_contract_year_start = self._get_current_period_start()
             await self._async_save_state()
 
     async def _async_save_state(self) -> None:

--- a/custom_components/dynamic_energy_contract_calculator/solar_bonus.py
+++ b/custom_components/dynamic_energy_contract_calculator/solar_bonus.py
@@ -241,7 +241,15 @@ class SolarBonusTracker:
             if base_compensation <= 0:
                 return 0.0, 0.0
 
-            # Calculate how much production is still eligible for bonus
+            # Only kWh that actually earn the bonus count towards the annual
+            # limit, so feed-in at night or at negative prices does not use it
+            # up. Neither supplier settles this outright: Zonneplan writes "de
+            # bonus geldt tot 7.500 kWh teruglevering per kalenderjaar" and
+            # NextEnergy "je kunt tot 6.000 kWh profiteren van de Zonnebonus
+            # per contract jaar". Both phrase the limit as a cap on bonus, not
+            # on feed-in, and that is also the reading that favours the user.
+            # Counting gross feed-in instead would only mean reaching the cap
+            # sooner, and would apply to both suppliers alike.
             remaining_eligible_kwh = annual_limit_kwh - self._year_production_kwh
             if remaining_eligible_kwh <= 0:
                 return 0.0, 0.0

--- a/custom_components/dynamic_energy_contract_calculator/strings.json
+++ b/custom_components/dynamic_energy_contract_calculator/strings.json
@@ -1,4 +1,24 @@
 {
+  "selector": {
+    "solar_bonus_base": {
+      "options": {
+        "market_plus_markup": "Market price + production compensation (Zonneplan)",
+        "market_only": "Market price only (NextEnergy)"
+      }
+    },
+    "solar_bonus_window_mode": {
+      "options": {
+        "sunrise_sunset": "Sunrise to sunset (Zonneplan)",
+        "fixed_hours": "Fixed clock hours (NextEnergy 06:00-22:00)"
+      }
+    },
+    "solar_bonus_limit_period": {
+      "options": {
+        "calendar_year": "Calendar year (Zonneplan)",
+        "contract_year": "Contract year (NextEnergy)"
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -35,8 +55,13 @@
           "per_day_grid_operator_gas_connection_fee": "Gas connection fee per day",
           "per_day_supplier_gas_standing_charge": "Gas standing charge per day",
           "solar_bonus_enabled": "Enable solar bonus (zonnebonus)",
-          "solar_bonus_percentage": "Solar bonus percentage",
-          "solar_bonus_annual_kwh_limit": "Solar bonus annual kWh limit",
+          "solar_bonus_percentage": "Solar bonus percentage (Zonneplan 10%, NextEnergy 50%)",
+          "solar_bonus_annual_kwh_limit": "Solar bonus annual kWh limit (Zonneplan 7500, NextEnergy 6000)",
+          "solar_bonus_base": "Solar bonus applies to",
+          "solar_bonus_window_mode": "Solar bonus time window",
+          "solar_bonus_start_hour": "Solar bonus start hour (fixed window only, NextEnergy 6)",
+          "solar_bonus_end_hour": "Solar bonus end hour (fixed window only, NextEnergy 22)",
+          "solar_bonus_limit_period": "Solar bonus limit period",
           "contract_start_date": "Contract start date",
           "reset_on_contract_anniversary": "Reset all meters on contract anniversary"
         }
@@ -79,8 +104,13 @@
           "per_day_grid_operator_gas_connection_fee": "Gas connection fee per day",
           "per_day_supplier_gas_standing_charge": "Gas standing charge per day",
           "solar_bonus_enabled": "Enable solar bonus (zonnebonus)",
-          "solar_bonus_percentage": "Solar bonus percentage",
-          "solar_bonus_annual_kwh_limit": "Solar bonus annual kWh limit",
+          "solar_bonus_percentage": "Solar bonus percentage (Zonneplan 10%, NextEnergy 50%)",
+          "solar_bonus_annual_kwh_limit": "Solar bonus annual kWh limit (Zonneplan 7500, NextEnergy 6000)",
+          "solar_bonus_base": "Solar bonus applies to",
+          "solar_bonus_window_mode": "Solar bonus time window",
+          "solar_bonus_start_hour": "Solar bonus start hour (fixed window only, NextEnergy 6)",
+          "solar_bonus_end_hour": "Solar bonus end hour (fixed window only, NextEnergy 22)",
+          "solar_bonus_limit_period": "Solar bonus limit period",
           "contract_start_date": "Contract start date",
           "reset_on_contract_anniversary": "Reset all meters on contract anniversary"
         }

--- a/custom_components/dynamic_energy_contract_calculator/strings.json
+++ b/custom_components/dynamic_energy_contract_calculator/strings.json
@@ -30,7 +30,7 @@
       },
       "load_preset": {
         "title": "Load Supplier Preset",
-        "description": "Select a predefined supplier configuration to automatically set all price parameters. Choose 'Zonneplan 2026' to load Zonneplan contract terms, or 'None' to keep current settings.",
+        "description": "Select a predefined supplier configuration. A preset only overwrites the settings it defines, so values it leaves out keep whatever you configured. 'NextEnergy 2026' carries the Zonnebonus terms only, because NextEnergy does not publish its supply tariffs. Choose 'None' to keep current settings.",
         "data": {
           "supplier_preset": "Supplier preset"
         }
@@ -79,7 +79,7 @@
       },
       "load_preset": {
         "title": "Load Supplier Preset",
-        "description": "Select a predefined supplier configuration to automatically set all price parameters. Choose 'Zonneplan 2026' to load Zonneplan contract terms, or 'None' to keep current settings.",
+        "description": "Select a predefined supplier configuration. A preset only overwrites the settings it defines, so values it leaves out keep whatever you configured. 'NextEnergy 2026' carries the Zonnebonus terms only, because NextEnergy does not publish its supply tariffs. Choose 'None' to keep current settings.",
         "data": {
           "supplier_preset": "Supplier preset"
         }

--- a/custom_components/dynamic_energy_contract_calculator/translations/en.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/en.json
@@ -1,4 +1,24 @@
 {
+  "selector": {
+    "solar_bonus_base": {
+      "options": {
+        "market_plus_markup": "Market price + production compensation (Zonneplan)",
+        "market_only": "Market price only (NextEnergy)"
+      }
+    },
+    "solar_bonus_window_mode": {
+      "options": {
+        "sunrise_sunset": "Sunrise to sunset (Zonneplan)",
+        "fixed_hours": "Fixed clock hours (NextEnergy 06:00-22:00)"
+      }
+    },
+    "solar_bonus_limit_period": {
+      "options": {
+        "calendar_year": "Calendar year (Zonneplan)",
+        "contract_year": "Contract year (NextEnergy)"
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -10,7 +30,7 @@
       },
       "load_preset": {
         "title": "Load Supplier Preset",
-        "description": "Select a predefined supplier configuration to automatically set all price parameters. Choose 'Zonneplan 2026' to load Zonneplan contract terms, or 'None' to keep current settings.",
+        "description": "Select a predefined supplier configuration. A preset only overwrites the settings it defines, so values it leaves out keep whatever you configured. 'NextEnergy 2026' carries the Zonnebonus terms only, because NextEnergy does not publish its supply tariffs. Choose 'None' to keep current settings.",
         "data": {
           "supplier_preset": "Supplier preset"
         }
@@ -35,8 +55,13 @@
           "per_day_grid_operator_gas_connection_fee": "Gas connection fee per day",
           "per_day_supplier_gas_standing_charge": "Gas standing charge per day",
           "solar_bonus_enabled": "Enable solar bonus (zonnebonus)",
-          "solar_bonus_percentage": "Solar bonus percentage",
-          "solar_bonus_annual_kwh_limit": "Solar bonus annual kWh limit",
+          "solar_bonus_percentage": "Solar bonus percentage (Zonneplan 10%, NextEnergy 50%)",
+          "solar_bonus_annual_kwh_limit": "Solar bonus annual kWh limit (Zonneplan 7500, NextEnergy 6000)",
+          "solar_bonus_base": "Solar bonus applies to",
+          "solar_bonus_window_mode": "Solar bonus time window",
+          "solar_bonus_start_hour": "Solar bonus start hour (fixed window only, NextEnergy 6)",
+          "solar_bonus_end_hour": "Solar bonus end hour (fixed window only, NextEnergy 22)",
+          "solar_bonus_limit_period": "Solar bonus limit period",
           "contract_start_date": "Contract start date",
           "reset_on_contract_anniversary": "Reset all meters on contract anniversary"
         }
@@ -54,7 +79,7 @@
       },
       "load_preset": {
         "title": "Load Supplier Preset",
-        "description": "Select a predefined supplier configuration to automatically set all price parameters. Choose 'Zonneplan 2026' to load Zonneplan contract terms, or 'None' to keep current settings.",
+        "description": "Select a predefined supplier configuration. A preset only overwrites the settings it defines, so values it leaves out keep whatever you configured. 'NextEnergy 2026' carries the Zonnebonus terms only, because NextEnergy does not publish its supply tariffs. Choose 'None' to keep current settings.",
         "data": {
           "supplier_preset": "Supplier preset"
         }
@@ -79,8 +104,13 @@
           "per_day_grid_operator_gas_connection_fee": "Gas connection fee per day",
           "per_day_supplier_gas_standing_charge": "Gas standing charge per day",
           "solar_bonus_enabled": "Enable solar bonus (zonnebonus)",
-          "solar_bonus_percentage": "Solar bonus percentage",
-          "solar_bonus_annual_kwh_limit": "Solar bonus annual kWh limit",
+          "solar_bonus_percentage": "Solar bonus percentage (Zonneplan 10%, NextEnergy 50%)",
+          "solar_bonus_annual_kwh_limit": "Solar bonus annual kWh limit (Zonneplan 7500, NextEnergy 6000)",
+          "solar_bonus_base": "Solar bonus applies to",
+          "solar_bonus_window_mode": "Solar bonus time window",
+          "solar_bonus_start_hour": "Solar bonus start hour (fixed window only, NextEnergy 6)",
+          "solar_bonus_end_hour": "Solar bonus end hour (fixed window only, NextEnergy 22)",
+          "solar_bonus_limit_period": "Solar bonus limit period",
           "contract_start_date": "Contract start date",
           "reset_on_contract_anniversary": "Reset all meters on contract anniversary"
         }

--- a/custom_components/dynamic_energy_contract_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/nl.json
@@ -30,7 +30,7 @@
       },
       "load_preset": {
         "title": "Leverancier Preset Laden",
-        "description": "Selecteer een vooraf gedefinieerde leveranciersconfiguratie om alle prijsparameters automatisch in te stellen. Kies 'Zonneplan 2025' voor Zonneplan contractvoorwaarden, of 'None' om huidige instellingen te behouden.",
+        "description": "Selecteer een vooraf gedefinieerde leveranciersconfiguratie. Een preset overschrijft alleen de instellingen die hij zelf bevat; wat hij weglaat behoudt jouw eigen waarde. 'NextEnergy 2026' bevat uitsluitend de Zonnebonus-voorwaarden, omdat NextEnergy zijn leveringstarieven niet publiceert. Kies 'None' om de huidige instellingen te behouden.",
         "data": {
           "supplier_preset": "Leverancier preset"
         }
@@ -79,7 +79,7 @@
       },
       "load_preset": {
         "title": "Leverancier Preset Laden",
-        "description": "Selecteer een vooraf gedefinieerde leveranciersconfiguratie om alle prijsparameters automatisch in te stellen. Kies 'Zonneplan 2025' voor Zonneplan contractvoorwaarden, of 'None' om huidige instellingen te behouden.",
+        "description": "Selecteer een vooraf gedefinieerde leveranciersconfiguratie. Een preset overschrijft alleen de instellingen die hij zelf bevat; wat hij weglaat behoudt jouw eigen waarde. 'NextEnergy 2026' bevat uitsluitend de Zonnebonus-voorwaarden, omdat NextEnergy zijn leveringstarieven niet publiceert. Kies 'None' om de huidige instellingen te behouden.",
         "data": {
           "supplier_preset": "Leverancier preset"
         }

--- a/custom_components/dynamic_energy_contract_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/nl.json
@@ -1,4 +1,24 @@
 {
+  "selector": {
+    "solar_bonus_base": {
+      "options": {
+        "market_plus_markup": "Marktprijs + terugleververgoeding (Zonneplan)",
+        "market_only": "Alleen de beursprijs (NextEnergy)"
+      }
+    },
+    "solar_bonus_window_mode": {
+      "options": {
+        "sunrise_sunset": "Zonsopkomst tot zonsondergang (Zonneplan)",
+        "fixed_hours": "Vaste klokuren (NextEnergy 06:00-22:00)"
+      }
+    },
+    "solar_bonus_limit_period": {
+      "options": {
+        "calendar_year": "Kalenderjaar (Zonneplan)",
+        "contract_year": "Contractjaar (NextEnergy)"
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -35,8 +55,13 @@
           "per_day_grid_operator_gas_connection_fee": "Aansluitkosten gas per dag",
           "per_day_supplier_gas_standing_charge": "Vaste kosten gas per dag",
           "solar_bonus_enabled": "Zonnebonus inschakelen",
-          "solar_bonus_percentage": "Zonnebonus percentage",
-          "solar_bonus_annual_kwh_limit": "Zonnebonus jaarlijkse kWh limiet",
+          "solar_bonus_percentage": "Zonnebonus percentage (Zonneplan 10%, NextEnergy 50%)",
+          "solar_bonus_annual_kwh_limit": "Zonnebonus jaarlijkse kWh limiet (Zonneplan 7500, NextEnergy 6000)",
+          "solar_bonus_base": "Zonnebonus wordt berekend over",
+          "solar_bonus_window_mode": "Zonnebonus tijdvenster",
+          "solar_bonus_start_hour": "Zonnebonus beginuur (alleen bij vast venster, NextEnergy 6)",
+          "solar_bonus_end_hour": "Zonnebonus einduur (alleen bij vast venster, NextEnergy 22)",
+          "solar_bonus_limit_period": "Zonnebonus limietperiode",
           "contract_start_date": "Contract startdatum",
           "reset_on_contract_anniversary": "Alle meters resetten op contract verjaardag"
         }
@@ -79,8 +104,13 @@
           "per_day_grid_operator_gas_connection_fee": "Aansluitkosten gas per dag",
           "per_day_supplier_gas_standing_charge": "Vaste kosten gas per dag",
           "solar_bonus_enabled": "Zonnebonus inschakelen",
-          "solar_bonus_percentage": "Zonnebonus percentage",
-          "solar_bonus_annual_kwh_limit": "Zonnebonus jaarlijkse kWh limiet",
+          "solar_bonus_percentage": "Zonnebonus percentage (Zonneplan 10%, NextEnergy 50%)",
+          "solar_bonus_annual_kwh_limit": "Zonnebonus jaarlijkse kWh limiet (Zonneplan 7500, NextEnergy 6000)",
+          "solar_bonus_base": "Zonnebonus wordt berekend over",
+          "solar_bonus_window_mode": "Zonnebonus tijdvenster",
+          "solar_bonus_start_hour": "Zonnebonus beginuur (alleen bij vast venster, NextEnergy 6)",
+          "solar_bonus_end_hour": "Zonnebonus einduur (alleen bij vast venster, NextEnergy 22)",
+          "solar_bonus_limit_period": "Zonnebonus limietperiode",
           "contract_start_date": "Contract startdatum",
           "reset_on_contract_anniversary": "Alle meters resetten op contract verjaardag"
         }

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,7 +1,18 @@
 """Test supplier preset configurations."""
 
+import pytest
+
+from custom_components.dynamic_energy_contract_calculator.config_flow import (
+    _apply_preset,
+)
 from custom_components.dynamic_energy_contract_calculator.const import (
+    DEFAULT_PRICE_SETTINGS,
+    PRESET_GREENCHOICE_GAS_2026,
+    PRESET_NEXTENERGY_2026,
     PRESET_ZONNEPLAN_2026,
+    SOLAR_BONUS_BASE_MARKET_ONLY,
+    SOLAR_BONUS_LIMIT_CONTRACT_YEAR,
+    SOLAR_BONUS_WINDOW_FIXED_HOURS,
     SUPPLIER_PRESETS,
 )
 
@@ -121,3 +132,85 @@ def test_zonneplan_daily_costs_calculation():
         * vat_factor
     )
     assert abs(monthly_rebate - 43.33) < 0.01
+
+
+def test_nextenergy_preset_exists():
+    """Test that the NextEnergy preset is available."""
+    assert "nextenergy_2026" in SUPPLIER_PRESETS
+    assert SUPPLIER_PRESETS["nextenergy_2026"] == PRESET_NEXTENERGY_2026
+
+
+def test_nextenergy_preset_zonnebonus_terms():
+    """The preset carries NextEnergy's published Zonnebonus conditions."""
+    preset = PRESET_NEXTENERGY_2026
+
+    assert preset["solar_bonus_enabled"] is True
+    # 50% over the bare exchange price
+    assert preset["solar_bonus_percentage"] == 50.0
+    assert preset["solar_bonus_base"] == SOLAR_BONUS_BASE_MARKET_ONLY
+    # Fixed 06:00-22:00 window rather than sunrise to sunset
+    assert preset["solar_bonus_window_mode"] == SOLAR_BONUS_WINDOW_FIXED_HOURS
+    assert preset["solar_bonus_start_hour"] == 6.0
+    assert preset["solar_bonus_end_hour"] == 22.0
+    # 6000 kWh per contract year, not per calendar year
+    assert preset["solar_bonus_annual_kwh_limit"] == 6000.0
+    assert preset["solar_bonus_limit_period"] == SOLAR_BONUS_LIMIT_CONTRACT_YEAR
+    # NextEnergy settles on quarter-hour prices
+    assert preset["average_prices_to_hourly"] is False
+
+
+def test_nextenergy_preset_carries_no_supply_tariffs():
+    """NextEnergy does not publish supply tariffs, so the preset omits them.
+
+    Absent keys are never written, so loading this preset must not reset
+    tariffs the user entered from their own contract.
+    """
+    unpublished = {
+        "per_unit_supplier_electricity_markup",
+        "per_unit_government_electricity_tax",
+        "per_day_grid_operator_electricity_connection_fee",
+        "per_day_supplier_electricity_standing_charge",
+        "per_day_government_electricity_tax_rebate",
+    }
+    assert unpublished.isdisjoint(PRESET_NEXTENERGY_2026)
+
+
+def test_nextenergy_preset_preserves_existing_settings():
+    """Loading the NextEnergy preset leaves gas and electricity tariffs alone."""
+    current = dict(DEFAULT_PRICE_SETTINGS)
+    current.update(
+        {
+            "per_unit_supplier_electricity_markup": 0.0181,
+            "per_day_supplier_electricity_standing_charge": 0.1735,
+            "per_unit_supplier_gas_markup": 0.4105,
+            "per_day_supplier_gas_standing_charge": 0.4386,
+        }
+    )
+
+    result = _apply_preset(current, PRESET_NEXTENERGY_2026)
+
+    # Tariffs the user configured survive untouched
+    assert result["per_unit_supplier_electricity_markup"] == 0.0181
+    assert result["per_day_supplier_electricity_standing_charge"] == 0.1735
+    assert result["per_unit_supplier_gas_markup"] == 0.4105
+    assert result["per_day_supplier_gas_standing_charge"] == 0.4386
+
+    # The bonus terms are applied
+    assert result["solar_bonus_percentage"] == 50.0
+    assert result["solar_bonus_base"] == SOLAR_BONUS_BASE_MARKET_ONLY
+    assert result["solar_bonus_annual_kwh_limit"] == 6000.0
+
+
+def test_nextenergy_and_greenchoice_presets_compose():
+    """Electricity from NextEnergy and gas from Greenchoice must coexist."""
+    combined = _apply_preset(dict(DEFAULT_PRICE_SETTINGS), PRESET_NEXTENERGY_2026)
+    combined = _apply_preset(combined, PRESET_GREENCHOICE_GAS_2026)
+
+    # Gas preset must not clear the NextEnergy Zonnebonus terms
+    assert combined["solar_bonus_enabled"] is True
+    assert combined["solar_bonus_percentage"] == 50.0
+    assert combined["solar_bonus_annual_kwh_limit"] == 6000.0
+    assert combined["solar_bonus_base"] == SOLAR_BONUS_BASE_MARKET_ONLY
+
+    # And the gas tariffs are loaded
+    assert combined["per_unit_supplier_gas_markup"] == pytest.approx(0.41050)

--- a/tests/test_sensor_additional.py
+++ b/tests/test_sensor_additional.py
@@ -626,7 +626,9 @@ async def test_current_price_schedule_sunrise_sunset_update(hass: HomeAssistant)
 
         await calls["callback"](sunrise)
 
-    assert sensor.native_value == pytest.approx(1.5)
+    # Sunrise is what this update exists for, so the state it writes has to
+    # carry the bonus — 1.5 + 10% — like the forecast attributes do.
+    assert sensor.native_value == pytest.approx(1.65)
 
 
 async def test_solar_bonus_status_sensor_update(hass: HomeAssistant):
@@ -1152,10 +1154,19 @@ async def test_current_price_async_update_without_averaging_schedules_sunrise(
         "scheduled", True
     )
 
-    await sensor.async_update()
+    # Pin daylight rather than depend on the wall clock at test time
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(1.1)
+    assert called["scheduled"] is True
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: False)
+        await sensor.async_update()
 
     assert sensor.native_value == pytest.approx(1.0)
-    assert called["scheduled"] is True
 
 
 async def test_sensor_async_setup_entry_creates_new_trackers(hass: HomeAssistant):
@@ -1449,3 +1460,122 @@ async def test_is_contract_anniversary_helper():
     assert _is_contract_anniversary("2020-02-29", date(2025, 3, 1)) is False
     # Feb 29 on actual leap year matches exactly
     assert _is_contract_anniversary("2020-02-29", date(2024, 2, 29)) is True
+
+
+async def test_current_price_state_includes_solar_bonus_without_averaging(
+    hass: HomeAssistant,
+):
+    """Without averaging the state is calculated directly, and must carry the bonus.
+
+    net_prices_today already includes it, so a state without it contradicts
+    the sensor's own attributes.
+    """
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Direct Price",
+        "direct-price",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": False,
+            "per_unit_supplier_electricity_production_markup": 0.02,
+            "solar_bonus_enabled": True,
+            "solar_bonus_percentage": 10.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "direct-price")}),
+    )
+    hass.states.async_set("sensor.price", 0.10)
+    sensor._schedule_sunrise_sunset_updates = lambda: None
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(0.132)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: False)
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(0.12)
+
+
+async def test_current_price_fallback_includes_solar_bonus(hass: HomeAssistant):
+    """The averaged path falls back to a direct calculation, which needs the bonus too.
+
+    A price sensor that publishes no raw_today leaves _update_current_price
+    with nothing to match, so averaging being enabled is no guarantee the
+    state comes from the converted forecast.
+    """
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Fallback Price",
+        "fallback-price",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": True,
+            "per_unit_supplier_electricity_production_markup": 0.02,
+            "solar_bonus_enabled": True,
+            "solar_bonus_percentage": 10.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "fallback-price")}),
+    )
+    hass.states.async_set("sensor.price", 0.10)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(0.132)
+
+
+async def test_scheduled_sun_event_writes_bonus_price(hass: HomeAssistant):
+    """The sunrise/sunset update exists to change the price, so it must apply the bonus."""
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Sun Event",
+        "sun-event-bonus",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": False,
+            "per_unit_supplier_electricity_production_markup": 0.02,
+            "solar_bonus_enabled": True,
+            "solar_bonus_percentage": 10.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "sun-event-bonus")}),
+    )
+    hass.states.async_set("sensor.price", 0.10)
+    now = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+    sunrise = now + timedelta(hours=1)
+    calls = {}
+    sensor.async_write_ha_state = lambda *a, **k: calls.setdefault("write", True)
+
+    def fake_track_point_in_time(hass_arg, callback, when):
+        calls["callback"] = callback
+        return lambda: None
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sensor_module.dt_util, "now", lambda: now)
+        mp.setattr(
+            sensor,
+            "_get_sunrise_sunset_times",
+            lambda date_obj: (sunrise, now + timedelta(hours=5)),
+        )
+        mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
+        mp.setattr(sensor_module, "async_track_point_in_time", fake_track_point_in_time)
+        sensor._schedule_sunrise_sunset_updates()
+        await calls["callback"](sunrise)
+
+    assert sensor.native_value == pytest.approx(0.132)
+    assert calls["write"] is True

--- a/tests/test_sensor_additional.py
+++ b/tests/test_sensor_additional.py
@@ -23,6 +23,8 @@ from custom_components.dynamic_energy_contract_calculator.const import (
     CONF_SOURCE_TYPE,
     CONF_SOURCES,
     DOMAIN,
+    SOLAR_BONUS_BASE_MARKET_ONLY,
+    SOLAR_BONUS_WINDOW_FIXED_HOURS,
     SOURCE_TYPE_CONSUMPTION,
     SOURCE_TYPE_GAS,
     SOURCE_TYPE_PRODUCTION,
@@ -517,6 +519,71 @@ async def test_current_price_average_and_convert_helpers(hass: HomeAssistant):
     assert converted[1]["value"] == pytest.approx(2.0)
     assert converted[1]["solar_bonus_applied"] is False
     assert sensor._convert_raw_prices("invalid") is None
+
+
+async def test_convert_raw_prices_fixed_window_market_only(hass: HomeAssistant):
+    """Forecast prices follow the fixed window and the market-only bonus base.
+
+    A fixed window is defined in local clock hours, so UTC forecast
+    timestamps are converted first (hass runs on Europe/Amsterdam here).
+    """
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Helper",
+        "helper-nextenergy",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": True,
+            "per_unit_supplier_electricity_production_markup": -0.022,
+            "solar_bonus_enabled": True,
+            "solar_bonus_percentage": 50.0,
+            "solar_bonus_base": SOLAR_BONUS_BASE_MARKET_ONLY,
+            "solar_bonus_window_mode": SOLAR_BONUS_WINDOW_FIXED_HOURS,
+            "solar_bonus_start_hour": 6.0,
+            "solar_bonus_end_hour": 22.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "helper-nextenergy")}),
+    )
+
+    converted = sensor._convert_raw_prices(
+        [
+            {"start": "2026-06-15T03:00:00+00:00", "value": 0.10},  # 05:00 local
+            {"start": "2026-06-15T10:00:00+00:00", "value": 0.10},  # 12:00 local
+            {"start": "2026-06-15T20:00:00+00:00", "value": 0.10},  # 22:00 local
+            # 13:00 local, below the feed-in charge: the bonus is still due on
+            # the market price, even though the net compensation is negative.
+            {"start": "2026-06-15T11:00:00+00:00", "value": 0.015},
+        ]
+    )
+    by_start = {entry["start"]: entry for entry in converted}
+
+    # Outside the 06:00-22:00 local window: compensation only, no bonus
+    before = by_start["2026-06-15T03:00:00+00:00"]
+    assert before["solar_bonus_applied"] is False
+    assert before["value"] == pytest.approx(0.10 - 0.022)
+
+    # 22:00 local is the exclusive end of the window
+    after = by_start["2026-06-15T20:00:00+00:00"]
+    assert after["solar_bonus_applied"] is False
+    assert after["value"] == pytest.approx(0.10 - 0.022)
+
+    # Inside the window: 50% of the market price on top of the compensation
+    midday = by_start["2026-06-15T10:00:00+00:00"]
+    assert midday["solar_bonus_applied"] is True
+    assert midday["value"] == pytest.approx(0.10 - 0.022 + 0.05)
+
+    low = by_start["2026-06-15T11:00:00+00:00"]
+    assert low["solar_bonus_applied"] is True
+    assert low["value"] == pytest.approx(0.015 - 0.022 + 0.0075)
+
+    # An unusable timestamp cannot be placed in the window, so no bonus
+    assert sensor._is_in_bonus_window_at("not-a-timestamp") is False
+    # A naive timestamp is read as local time
+    assert sensor._is_in_bonus_window_at(datetime(2026, 6, 15, 12, 0, 0)) is True
 
 
 async def test_current_price_scheduling_and_cleanup(hass: HomeAssistant):

--- a/tests/test_sensor_additional.py
+++ b/tests/test_sensor_additional.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import AsyncMock
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from custom_components.dynamic_energy_contract_calculator.entity import (
@@ -688,7 +690,7 @@ async def test_current_price_schedule_sunrise_sunset_update(hass: HomeAssistant)
             fake_track_point_in_time,
         )
 
-        sensor._schedule_sunrise_sunset_updates()
+        sensor._schedule_bonus_window_updates()
         assert calls["when"] == sunrise
 
         await calls["callback"](sunrise)
@@ -1217,9 +1219,7 @@ async def test_current_price_async_update_without_averaging_schedules_sunrise(
     )
     hass.states.async_set("sensor.price", 1.0, {"raw_today": [], "raw_tomorrow": []})
     called = {}
-    sensor._schedule_sunrise_sunset_updates = lambda: called.setdefault(
-        "scheduled", True
-    )
+    sensor._schedule_bonus_window_updates = lambda: called.setdefault("scheduled", True)
 
     # Pin daylight rather than depend on the wall clock at test time
     with pytest.MonkeyPatch.context() as mp:
@@ -1336,7 +1336,7 @@ async def test_current_price_handle_sunrise_sunset_callback_invalid_float(
             lambda date_obj: (now + timedelta(hours=1), None),
         )
         mp.setattr(sensor_module, "async_track_point_in_time", fake_track_point_in_time)
-        sensor._schedule_sunrise_sunset_updates()
+        sensor._schedule_bonus_window_updates()
         await calls["callback"](now + timedelta(hours=1))
 
     assert calls["writes"] == 1
@@ -1555,7 +1555,7 @@ async def test_current_price_state_includes_solar_bonus_without_averaging(
         device=DeviceInfo(identifiers={("d", "direct-price")}),
     )
     hass.states.async_set("sensor.price", 0.10)
-    sensor._schedule_sunrise_sunset_updates = lambda: None
+    sensor._schedule_bonus_window_updates = lambda: None
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
@@ -1641,8 +1641,132 @@ async def test_scheduled_sun_event_writes_bonus_price(hass: HomeAssistant):
         )
         mp.setattr(sensor, "_is_daylight_at", lambda timestamp: True)
         mp.setattr(sensor_module, "async_track_point_in_time", fake_track_point_in_time)
-        sensor._schedule_sunrise_sunset_updates()
+        sensor._schedule_bonus_window_updates()
         await calls["callback"](sunrise)
 
     assert sensor.native_value == pytest.approx(0.132)
     assert calls["write"] is True
+
+
+async def test_schedule_bonus_window_updates_fixed_hours(hass: HomeAssistant):
+    """A fixed window schedules on its clock hours, not on the sun."""
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Fixed Window",
+        "fixed-window-schedule",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": False,
+            "solar_bonus_enabled": True,
+            "solar_bonus_window_mode": SOLAR_BONUS_WINDOW_FIXED_HOURS,
+            "solar_bonus_start_hour": 6.0,
+            "solar_bonus_end_hour": 22.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "fixed-window-schedule")}),
+    )
+    calls: dict[str, Any] = {}
+
+    def fake_track_point_in_time(hass_arg, callback, when):
+        calls["when"] = when
+        return lambda: None
+
+    def run_at(local_hour: int) -> datetime:
+        pinned = datetime(
+            2026, 6, 15, local_hour, 30, tzinfo=ZoneInfo("Europe/Amsterdam")
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sensor_module.dt_util, "now", lambda: pinned)
+            mp.setattr(
+                sensor_module,
+                "_astral_sun",
+                lambda *a, **k: pytest.fail("fixed window must not consult the sun"),
+            )
+            mp.setattr(
+                sensor_module,
+                "async_track_point_in_time",
+                fake_track_point_in_time,
+            )
+            sensor._schedule_bonus_window_updates()
+        return calls["when"]
+
+    # Before the window opens: next edge is today's start hour
+    assert run_at(4).hour == 6
+    assert run_at(4).date() == date(2026, 6, 15)
+
+    # Inside the window: next edge is today's end hour
+    assert run_at(12).hour == 22
+    assert run_at(12).date() == date(2026, 6, 15)
+
+    # After it closes: next edge is tomorrow's start hour
+    assert run_at(23).hour == 6
+    assert run_at(23).date() == date(2026, 6, 16)
+
+
+async def test_current_price_state_matches_attributes_nextenergy(
+    hass: HomeAssistant,
+):
+    """The state must not contradict net_prices_today for a NextEnergy setup.
+
+    NextEnergy settles on quarter-hour prices, so average_prices_to_hourly is
+    off and the state is calculated directly instead of read from the
+    converted forecast. Both paths have to agree, including on the
+    market-only bonus base.
+    """
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "NextEnergy Production",
+        "nextenergy-state",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings={
+            "production_price_include_vat": False,
+            "average_prices_to_hourly": False,
+            "per_unit_supplier_electricity_production_markup": 0.0,
+            "solar_bonus_enabled": True,
+            "solar_bonus_percentage": 50.0,
+            "solar_bonus_base": SOLAR_BONUS_BASE_MARKET_ONLY,
+            "solar_bonus_window_mode": SOLAR_BONUS_WINDOW_FIXED_HOURS,
+            "solar_bonus_start_hour": 6.0,
+            "solar_bonus_end_hour": 22.0,
+            "vat_percentage": 0.0,
+        },
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("d", "nextenergy-state")}),
+    )
+    hass.states.async_set(
+        "sensor.price",
+        0.10,
+        {"raw_today": [{"start": "2026-06-15T10:00:00+00:00", "value": 0.10}]},
+    )
+    # The pinned clock is in the past, so a real timer would fire at once on
+    # an entity that was never added to a platform.
+    sensor._schedule_bonus_window_updates = lambda: None
+
+    # 12:00 local, inside the 06:00-22:00 window
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            sensor_module.dt_util,
+            "now",
+            lambda: datetime(2026, 6, 15, 10, 0, tzinfo=timezone.utc),
+        )
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(0.15)
+    forecast = sensor.extra_state_attributes["net_prices_today"]
+    assert forecast[0]["value"] == pytest.approx(0.15)
+    assert sensor.native_value == pytest.approx(forecast[0]["value"])
+
+    # 04:00 local, outside the window
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            sensor_module.dt_util,
+            "now",
+            lambda: datetime(2026, 6, 15, 2, 0, tzinfo=timezone.utc),
+        )
+        await sensor.async_update()
+
+    assert sensor.native_value == pytest.approx(0.10)

--- a/tests/test_solar_bonus.py
+++ b/tests/test_solar_bonus.py
@@ -5,6 +5,12 @@ from datetime import date, datetime, timezone
 from unittest.mock import patch
 from homeassistant.core import HomeAssistant
 
+from custom_components.dynamic_energy_contract_calculator.const import (
+    SOLAR_BONUS_BASE_MARKET_ONLY,
+    SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+    SOLAR_BONUS_LIMIT_CONTRACT_YEAR,
+    SOLAR_BONUS_WINDOW_FIXED_HOURS,
+)
 from custom_components.dynamic_energy_contract_calculator.solar_bonus import (
     SolarBonusTracker,
 )
@@ -537,7 +543,10 @@ async def test_solar_bonus_reset_year_with_contract_date(hass: HomeAssistant):
         return_value=datetime(2025, 7, 1, 12, 0, 0, tzinfo=timezone.utc),
     ):
         tracker = await SolarBonusTracker.async_create(
-            hass, "test_entry_25", contract_start_date="2024-01-15"
+            hass,
+            "test_entry_25",
+            contract_start_date="2024-01-15",
+            limit_period=SOLAR_BONUS_LIMIT_CONTRACT_YEAR,
         )
 
         # Add some production
@@ -559,6 +568,207 @@ async def test_solar_bonus_reset_year_with_contract_date(hass: HomeAssistant):
         assert tracker.total_bonus_euro == 0.0
         # Contract year start should be updated
         assert tracker._current_contract_year_start == date(2025, 1, 15)
+
+
+@pytest.mark.parametrize(
+    ("hour", "expect_bonus"),
+    [(5, False), (6, True), (13, True), (21, True), (22, False), (23, False)],
+)
+async def test_fixed_hour_window(hass: HomeAssistant, hour: int, expect_bonus: bool):
+    """A fixed window pays between start_hour and end_hour, exclusive of the end."""
+    with patch(
+        "homeassistant.util.dt.now",
+        return_value=datetime(2026, 6, 15, hour, 30, 0, tzinfo=timezone.utc),
+    ):
+        tracker = await SolarBonusTracker.async_create(hass, f"fixed_window_{hour}")
+
+        bonus, eligible = await tracker.async_calculate_bonus(
+            delta_kwh=10.0,
+            base_price=0.10,
+            production_markup=0.0,
+            bonus_percentage=50.0,
+            annual_limit_kwh=6000.0,
+            bonus_base=SOLAR_BONUS_BASE_MARKET_ONLY,
+            window_mode=SOLAR_BONUS_WINDOW_FIXED_HOURS,
+            start_hour=6.0,
+            end_hour=22.0,
+        )
+
+    if expect_bonus:
+        assert bonus == pytest.approx(10.0 * 0.10 * 0.5)
+        assert eligible == 10.0
+    else:
+        assert bonus == 0.0
+        assert eligible == 0.0
+
+
+async def test_fixed_window_ignores_sun_state(hass: HomeAssistant):
+    """A fixed window must not consult the sun, unlike sunrise-to-sunset."""
+    hass.states.async_set("sun.sun", "below_horizon")
+
+    with patch(
+        "homeassistant.util.dt.now",
+        return_value=datetime(2026, 12, 21, 7, 0, 0, tzinfo=timezone.utc),
+    ):
+        tracker = await SolarBonusTracker.async_create(hass, "winter_morning")
+
+        bonus, _ = await tracker.async_calculate_bonus(
+            delta_kwh=5.0,
+            base_price=0.10,
+            production_markup=0.0,
+            bonus_percentage=50.0,
+            annual_limit_kwh=6000.0,
+            bonus_base=SOLAR_BONUS_BASE_MARKET_ONLY,
+            window_mode=SOLAR_BONUS_WINDOW_FIXED_HOURS,
+        )
+
+    assert bonus == pytest.approx(5.0 * 0.10 * 0.5)
+
+
+async def test_market_only_base_excludes_production_markup(hass: HomeAssistant):
+    """A market-only bonus is a percentage of the bare market price."""
+    tracker = await SolarBonusTracker.async_create(hass, "market_only_base")
+
+    with patch.object(tracker, "is_daylight", return_value=True):
+        bonus, _ = await tracker.async_calculate_bonus(
+            delta_kwh=100.0,
+            base_price=0.10,
+            production_markup=-0.022,
+            bonus_percentage=50.0,
+            annual_limit_kwh=6000.0,
+            bonus_base=SOLAR_BONUS_BASE_MARKET_ONLY,
+        )
+
+    # 50% of the market price alone, feed-in charges do not reduce it
+    assert bonus == pytest.approx(100.0 * 0.10 * 0.5)
+
+
+async def test_market_only_base_pays_below_feed_in_charge(hass: HomeAssistant):
+    """Feed-in charges must not suppress a market-only bonus at low prices.
+
+    With a €0.022/kWh feed-in charge, market + markup is negative for any
+    market price under €0.022 — which would wrongly zero the bonus for a
+    supplier that pays over the bare market price.
+    """
+    tracker = await SolarBonusTracker.async_create(hass, "low_price_band")
+
+    with patch.object(tracker, "is_daylight", return_value=True):
+        market_only, _ = await tracker.async_calculate_bonus(
+            delta_kwh=100.0,
+            base_price=0.015,
+            production_markup=-0.022,
+            bonus_percentage=50.0,
+            annual_limit_kwh=6000.0,
+            bonus_base=SOLAR_BONUS_BASE_MARKET_ONLY,
+        )
+
+    assert market_only == pytest.approx(100.0 * 0.015 * 0.5)
+
+    other = await SolarBonusTracker.async_create(hass, "low_price_band_incl")
+    with patch.object(other, "is_daylight", return_value=True):
+        with_markup, _ = await other.async_calculate_bonus(
+            delta_kwh=100.0,
+            base_price=0.015,
+            production_markup=-0.022,
+            bonus_percentage=50.0,
+            annual_limit_kwh=6000.0,
+            bonus_base=SOLAR_BONUS_BASE_MARKET_PLUS_MARKUP,
+        )
+
+    # The full compensation is negative here, so no bonus is due
+    assert with_markup == 0.0
+
+
+async def test_market_only_base_still_skips_negative_prices(hass: HomeAssistant):
+    """No bonus is paid — and none is charged — at negative market prices."""
+    tracker = await SolarBonusTracker.async_create(hass, "negative_market")
+
+    with patch.object(tracker, "is_daylight", return_value=True):
+        bonus, eligible = await tracker.async_calculate_bonus(
+            delta_kwh=100.0,
+            base_price=-0.05,
+            production_markup=0.0,
+            bonus_percentage=50.0,
+            annual_limit_kwh=6000.0,
+            bonus_base=SOLAR_BONUS_BASE_MARKET_ONLY,
+        )
+
+    assert bonus == 0.0
+    assert eligible == 0.0
+
+
+async def test_calendar_year_counter_resets_without_contract_date(
+    hass: HomeAssistant,
+):
+    """Without a contract date the counter must still reset each calendar year."""
+    with patch(
+        "homeassistant.util.dt.now",
+        return_value=datetime(2026, 12, 31, 12, 0, 0, tzinfo=timezone.utc),
+    ):
+        tracker = await SolarBonusTracker.async_create(hass, "calendar_reset")
+
+        with patch.object(tracker, "is_daylight", return_value=True):
+            await tracker.async_calculate_bonus(
+                delta_kwh=5000.0,
+                base_price=0.10,
+                production_markup=0.02,
+                bonus_percentage=10.0,
+                annual_limit_kwh=7500.0,
+            )
+
+        assert tracker.year_production_kwh == 5000.0
+
+    # Roll over into the next calendar year
+    with patch(
+        "homeassistant.util.dt.now",
+        return_value=datetime(2027, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    ):
+        with patch.object(tracker, "is_daylight", return_value=True):
+            await tracker.async_calculate_bonus(
+                delta_kwh=10.0,
+                base_price=0.10,
+                production_markup=0.02,
+                bonus_percentage=10.0,
+                annual_limit_kwh=7500.0,
+            )
+
+        assert tracker.year_production_kwh == 10.0
+        assert tracker.total_bonus_euro == pytest.approx(10.0 * 0.12 * 0.10)
+
+
+async def test_nextenergy_annual_limit_is_capped(hass: HomeAssistant):
+    """The bonus stops once the annual limit is reached, feed-in continues."""
+    with patch(
+        "homeassistant.util.dt.now",
+        return_value=datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
+    ):
+        tracker = await SolarBonusTracker.async_create(
+            hass,
+            "nextenergy_cap",
+            contract_start_date="2026-03-01",
+            limit_period=SOLAR_BONUS_LIMIT_CONTRACT_YEAR,
+        )
+
+        kwargs = {
+            "base_price": 0.10,
+            "production_markup": 0.0,
+            "bonus_percentage": 50.0,
+            "annual_limit_kwh": 6000.0,
+            "bonus_base": SOLAR_BONUS_BASE_MARKET_ONLY,
+            "window_mode": SOLAR_BONUS_WINDOW_FIXED_HOURS,
+        }
+
+        _, eligible = await tracker.async_calculate_bonus(delta_kwh=5900.0, **kwargs)
+        assert eligible == 5900.0
+
+        # Only the remaining 100 kWh of this delta qualifies
+        bonus, eligible = await tracker.async_calculate_bonus(delta_kwh=500.0, **kwargs)
+        assert eligible == 100.0
+        assert bonus == pytest.approx(100.0 * 0.10 * 0.5)
+
+        bonus, eligible = await tracker.async_calculate_bonus(delta_kwh=500.0, **kwargs)
+        assert eligible == 0.0
+        assert bonus == 0.0
 
 
 # Note: Lines 89-90 (leap year fallback for last year) and 125-128 (exception handler fallback)


### PR DESCRIPTION
Closes #159.

> ⚠️ Stacked on #161 — that PR's commit is the first in this branch. Merge #161 first, then this diff reduces to the NextEnergy work alone.

## Description

The zonnebonus logic was written around Zonneplan's terms and hardcoded two of them, so a NextEnergy contract could not be expressed at all:

- the bonus window was always sunrise to sunset, where NextEnergy pays between a fixed 06:00 and 22:00;
- the bonus was always a percentage of market price **plus** the production markup, where NextEnergy pays a percentage of the bare market price.

The second one also suppressed the bonus outright. Feed-in costs are configured as a negative production markup, so market + markup goes negative for any market price below that charge, and the positive-price condition zeroed a bonus that was actually due.

### New settings

Defaults reproduce the existing Zonneplan behaviour exactly.

| Setting | Default | NextEnergy |
|---|---|---|
| `solar_bonus_base` | `market_plus_markup` | `market_only` |
| `solar_bonus_window_mode` | `sunrise_sunset` | `fixed_hours` |
| `solar_bonus_start_hour` / `_end_hour` | 6 / 22 | 6 / 22 |
| `solar_bonus_limit_period` | `calendar_year` | `contract_year` |

Both bonus paths follow them — the live calculation in the tracker and the forecast prices in the price sensor — as does the `solar_bonus_active` binary sensor. Fixed windows are compared in local clock hours, so UTC forecast timestamps are converted first, and the window edges are scheduled on those hours instead of on the sun.

### Preset

`PRESET_NEXTENERGY_2026` carries the Zonnebonus terms NextEnergy publishes: 50% over the bare exchange price, 06:00–22:00, 6000 kWh per contract year, quarter-hour settlement.

It deliberately carries **no supply tariffs**. NextEnergy does not publish its inkoopvergoeding, vaste leveringskosten or netbeheerkosten — those depend on when a customer signed up and are only visible in the app, which their own tariff page states. Comparison sites quote conflicting figures. Since `_apply_preset` only writes the keys a preset defines, omitting those fields leaves whatever the user entered from their own tarievenblad intact; filling them with guesses would silently overwrite correct values with wrong ones.

### Bug fixed along the way

The annual counter never reset without a contract start date — the reset was gated on that date being set, so a calendar-year limit stayed exhausted for good once reached. The limit period is now explicit.

⚠️ **Behaviour change:** entries that set a contract start date while their supplier caps per calendar year now reset in January instead of on the contract anniversary. That is correct for Zonneplan's 7500 kWh. Set `solar_bonus_limit_period` to `contract_year` to keep anniversary resets.

### Open point

Neither supplier settles whether the annual cap counts gross feed-in or only bonus-earning kWh. Zonneplan writes *"de bonus geldt tot 7.500 kWh teruglevering per kalenderjaar"* and NextEnergy *"je kunt tot 6.000 kWh profiteren van de Zonnebonus per contract jaar"* — both phrase the cap as a limit on bonus rather than on feed-in, which is also the reading that favours the user. That reasoning is recorded at the counter; the rule is shared by both suppliers, so switching to gross would be a single change rather than a per-supplier setting.

## Type of change

- [ ] `fix:` Bug fix (patch version bump)
- [x] `feat:` New feature (minor version bump)
- [ ] `feat!:` / `BREAKING CHANGE:` Breaking change (major version bump)
- [ ] `chore:` / `docs:` / `ci:` Maintenance or documentation (no version bump)

## Checklist

- [x] Commit title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests added or updated where applicable — new coverage for the fixed window, the market-only base including the band below the feed-in charge, both reset periods, the preset's composition with the Greenchoice gas preset, and state/attribute agreement
- [x] Documentation updated if needed — field labels and dropdown options in `strings.json`, `en.json` and `nl.json` name the supplier each option matches, since no preset is required to configure this by hand
- [x] CI is green — 230 tests pass, pre-commit and `mypy --strict` clean locally
- [x] PR targets the `dev` branch (not `main`, unless this is a hotfix)

## Screenshots / Logs (optional)

No preset is needed to use this: every NextEnergy condition is a setting, and the field labels name which supplier each option matches.

---
_Generated by [Claude Code](https://claude.ai/code/session_014yMhUYhzVhrDUjTV11LNDN)_